### PR TITLE
openshift ai

### DIFF
--- a/src/gen/java/org/mghpcc/aitelemetry/page/PageLayoutGen.java
+++ b/src/gen/java/org/mghpcc/aitelemetry/page/PageLayoutGen.java
@@ -33,6 +33,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.math.RoundingMode;
 import java.util.Map;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.core.Vertx;
 import java.lang.String;
 import io.vertx.ext.web.api.service.ServiceRequest;
 import io.vertx.core.json.JsonObject;
@@ -132,6 +134,88 @@ import io.vertx.core.Future;
  **/
 public abstract class PageLayoutGen<DEV> extends Object {
 	protected static final Logger LOG = LoggerFactory.getLogger(PageLayout.class);
+
+	///////////////
+	// webClient //
+	///////////////
+
+
+	/**	 The entity webClient
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonIgnore
+	@JsonInclude(Include.NON_NULL)
+	protected WebClient webClient;
+
+	/**	<br> The entity webClient
+	 *  is defined as null before being initialized. 
+	 * <br><a href="https://solr.apps-crc.testing/solr/#/computate/query?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.mghpcc.aitelemetry.page.PageLayout&fq=entiteVar_enUS_indexed_string:webClient">Find the entity webClient in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _webClient(Wrap<WebClient> w);
+
+	public WebClient getWebClient() {
+		return webClient;
+	}
+
+	public void setWebClient(WebClient webClient) {
+		this.webClient = webClient;
+	}
+	public static WebClient staticSetWebClient(SiteRequest siteRequest_, String o) {
+		return null;
+	}
+	protected PageLayout webClientInit() {
+		Wrap<WebClient> webClientWrap = new Wrap<WebClient>().var("webClient");
+		if(webClient == null) {
+			_webClient(webClientWrap);
+			Optional.ofNullable(webClientWrap.getO()).ifPresent(o -> {
+				setWebClient(o);
+			});
+		}
+		return (PageLayout)this;
+	}
+
+	///////////
+	// vertx //
+	///////////
+
+
+	/**	 The entity vertx
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonIgnore
+	@JsonInclude(Include.NON_NULL)
+	protected Vertx vertx;
+
+	/**	<br> The entity vertx
+	 *  is defined as null before being initialized. 
+	 * <br><a href="https://solr.apps-crc.testing/solr/#/computate/query?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.mghpcc.aitelemetry.page.PageLayout&fq=entiteVar_enUS_indexed_string:vertx">Find the entity vertx in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _vertx(Wrap<Vertx> w);
+
+	public Vertx getVertx() {
+		return vertx;
+	}
+
+	public void setVertx(Vertx vertx) {
+		this.vertx = vertx;
+	}
+	public static Vertx staticSetVertx(SiteRequest siteRequest_, String o) {
+		return null;
+	}
+	protected PageLayout vertxInit() {
+		Wrap<Vertx> vertxWrap = new Wrap<Vertx>().var("vertx");
+		if(vertx == null) {
+			_vertx(vertxWrap);
+			Optional.ofNullable(vertxWrap.getO()).ifPresent(o -> {
+				setVertx(o);
+			});
+		}
+		return (PageLayout)this;
+	}
 
 	//////////////////
 	// siteRequest_ //
@@ -3983,6 +4067,8 @@ public abstract class PageLayoutGen<DEV> extends Object {
 		Future.future(a -> a.complete()).compose(a -> {
 			Promise<Void> promise2 = Promise.promise();
 			try {
+				webClientInit();
+				vertxInit();
 				siteRequest_Init();
 				langInit();
 				requestVarsInit();
@@ -4133,6 +4219,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	public Object obtainPageLayout(String var) {
 		PageLayout oPageLayout = (PageLayout)this;
 		switch(var) {
+			case "webClient":
+				return oPageLayout.webClient;
+			case "vertx":
+				return oPageLayout.vertx;
 			case "siteRequest_":
 				return oPageLayout.siteRequest_;
 			case "lang":
@@ -4837,6 +4927,8 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	}
 
 	public static final String CLASS_SIMPLE_NAME = "PageLayout";
+	public static final String VAR_webClient = "webClient";
+	public static final String VAR_vertx = "vertx";
 	public static final String VAR_siteRequest_ = "siteRequest_";
 	public static final String VAR_lang = "lang";
 	public static final String VAR_requestVars = "requestVars";
@@ -4906,6 +4998,8 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	public static final String VAR_classIcon = "classIcon";
 	public static final String VAR_pageDescription = "pageDescription";
 
+	public static final String DISPLAY_NAME_webClient = "";
+	public static final String DISPLAY_NAME_vertx = "";
 	public static final String DISPLAY_NAME_siteRequest_ = "";
 	public static final String DISPLAY_NAME_lang = "";
 	public static final String DISPLAY_NAME_requestVars = "";
@@ -5012,6 +5106,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 	}
 	public static String displayNamePageLayout(String var) {
 		switch(var) {
+		case VAR_webClient:
+			return DISPLAY_NAME_webClient;
+		case VAR_vertx:
+			return DISPLAY_NAME_vertx;
 		case VAR_siteRequest_:
 			return DISPLAY_NAME_siteRequest_;
 		case VAR_lang:
@@ -5155,6 +5253,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 
 	public static String descriptionPageLayout(String var) {
 		switch(var) {
+		case VAR_webClient:
+			return "The current request object";
+		case VAR_vertx:
+			return "The current request object";
 		case VAR_siteRequest_:
 			return "The current request object";
 		case VAR_lang:
@@ -5222,6 +5324,10 @@ public abstract class PageLayoutGen<DEV> extends Object {
 
 	public static String classSimpleNamePageLayout(String var) {
 		switch(var) {
+		case VAR_webClient:
+			return "WebClient";
+		case VAR_vertx:
+			return "Vertx";
 		case VAR_siteRequest_:
 			return "SiteRequest";
 		case VAR_lang:

--- a/src/main/java/org/mghpcc/aitelemetry/model/gpudevice/GpuDeviceEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/gpudevice/GpuDeviceEnUSGenApiServiceImpl.java
@@ -2094,6 +2094,7 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			page.setSearchListGpuDevice_(listGpuDevice);
 			page.setSiteRequest_(siteRequest);
 			page.setServiceRequest(siteRequest.getServiceRequest());
+			page.setWebClient(webClient);
 			page.promiseDeepGpuDevicePage(siteRequest).onSuccess(a -> {
 				try {
 					JsonObject ctx = ComputateConfigKeys.getPageContext(config);
@@ -2268,6 +2269,7 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			page.setSearchListGpuDevice_(listGpuDevice);
 			page.setSiteRequest_(siteRequest);
 			page.setServiceRequest(siteRequest.getServiceRequest());
+			page.setWebClient(webClient);
 			page.promiseDeepGpuDevicePage(siteRequest).onSuccess(a -> {
 				try {
 					JsonObject ctx = ComputateConfigKeys.getPageContext(config);

--- a/src/main/java/org/mghpcc/aitelemetry/page/PageLayout.java
+++ b/src/main/java/org/mghpcc/aitelemetry/page/PageLayout.java
@@ -25,9 +25,11 @@ import org.mghpcc.aitelemetry.request.SiteRequest;
 import org.computate.vertx.config.ComputateConfigKeys;
 
 import io.vertx.core.Promise;
+import io.vertx.core.Vertx;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.api.service.ServiceRequest;
+import io.vertx.ext.web.client.WebClient;
 
 
 /**
@@ -51,6 +53,24 @@ public class PageLayout extends PageLayoutGen<Object> {
 	public static DateTimeFormatter FORMATZonedDateTimeDisplay = DateTimeFormatter.ofPattern("EEEE MMMM d yyyy H:mm:ss.SSS zz VV", Locale.US);
 
 	public static DateTimeFormatter FORMATTimeDisplay = DateTimeFormatter.ofPattern("h:mm a", Locale.US);
+
+	/**
+	 * {@inheritDoc}
+	 * Ignore: true
+	 * Description: The current request object
+	 * Initialized: true
+	**/
+	protected void _webClient(Wrap<WebClient> w) {
+	}
+
+	/**
+	 * {@inheritDoc}
+	 * Ignore: true
+	 * Description: The current request object
+	 * Initialized: true
+	**/
+	protected void _vertx(Wrap<Vertx> w) {
+	}
 
 	/**
 	 * Ignore: true

--- a/src/main/resources/templates/en-us/PageLayout.htm
+++ b/src/main/resources/templates/en-us/PageLayout.htm
@@ -14,6 +14,7 @@
     {{ WEB_COMPONENTS_CSS }}
     <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY=" crossorigin=""/>
     <link rel="stylesheet" href="https://unpkg.com/leaflet-draw/dist/leaflet.draw.css" />
+    <link rel="stylesheet" href="{{ STATIC_BASE_URL }}/css/leaflet.contextmenu.css"/>
     <link rel="stylesheet" href="{{ STATIC_BASE_URL }}/css/site.css"/>
 {%- endblock htmStylesPageLayout %}
     <style>{%- block htmStylePageLayout %}{%- endblock htmStylePageLayout %}</style>
@@ -31,7 +32,7 @@
           filters.push({ name: 'q', value: 'objectSuggest:' + event.target.value });
 
         fetch(
-          '{{ PUBLIC_SEARCH_URI }}?' + filters.map(function(m) { return m.name + '=' + encodeURIComponent(m.value) }).join('&')
+          '{{ USER_SEARCH_URI if userName is defined else PUBLIC_SEARCH_URI }}?' + filters.map(function(m) { return m.name + '=' + encodeURIComponent(m.value) }).join('&')
           , {
             headers: {'Content-Type':'application/json; charset=utf-8'}
           }).then(response => {
@@ -72,6 +73,7 @@
     <script src="{{ STATIC_BASE_URL }}/js/plotly-2.9.0.min.js"></script>
     <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js" integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo=" crossorigin=""></script>
     <script src="https://unpkg.com/leaflet-draw/dist/leaflet.draw.js"></script>
+    <script src="{{ STATIC_BASE_URL }}/js/leaflet.contextmenu.js"></script>
 {%- endblock htmScriptsPageLayout %}
 {%- block htmScriptPageLayout %}
 {%- endblock htmScriptPageLayout %}
@@ -81,13 +83,10 @@
     </script>
    </head>
   <body>
-    <wa-page>
+    <wa-page disable-sticky="header">
 {%- block htmBodyPageLayout %}
 {%- block htmBodyStartPageLayout %}
       <aside class="main-sidebar" slot="navigation">
-        <div class="text-end">
-          <wa-icon-button name="xmark" label="Close" data-drawer="close" class="hide-desktop sidebar-close-button"></wa-icon-button>
-        </div>
         <nav>
           <div>
             <a href="/">
@@ -112,13 +111,13 @@
               <div>
                 <wa-tooltip content="see or change your user profile">
                   <wa-button variant="brand" href="/user" label="see or change your user profile">
-                    <i slot="prefix" class="fad fa-house-user"></i>
+                    <i slot="prefix" class="fa-duotone fa-regular fa-house-user"></i>
                     <span>my user page</span>
                   </wa-button>
                 </wa-tooltip>
                 <wa-tooltip placement="right" content="sign out">
                   <wa-button variant="brand" href="{{ logoutUrl }}" label="sign out">
-                    <i slot="prefix" class="fa-duotone fa-person-from-portal"></i>
+                    <i slot="prefix" class="fa-duotone fa-regular fa-person-from-portal"></i>
                     <span>sign out</span>
                   </wa-button>
                 </wa-tooltip>
@@ -126,7 +125,7 @@
             </wa-details>
 {%- else %}
             <wa-button variant="brand" href="{{ SITE_BASE_URL }}/user">
-              <i class="fa-duotone fa-person-to-portal"></i> login
+              <i class="fa-duotone fa-regular fa-person-to-portal"></i> login
             </wa-button>
 {%- endif %}
           </div>
@@ -159,10 +158,10 @@
         </nav>
       </aside>
       <main>
-        <header class="margin-block flex gap-m align-items-center">
-          <wa-icon-button data-toggle-nav name="bars" class="nav-toggle-button hide-desktop" class="hide-desktop " label="open menu" appearance="text"></wa-icon-button>
+        <header slot="header" class="margin-block ">
+          <wa-icon-button data-toggle-nav name="bars" class="nav-toggle-button hide-desktop " label="open menu" appearance="text"></wa-icon-button>
           <wa-input placeholder="search" id="siteSearchInput">
-            <i slot="prefix" class="fa-light fa-magnifying-glass"></i>
+            <i slot="prefix" class="fa-duotone fa-regular fa-magnifying-glass"></i>
           </wa-input>
         </header>
         <wa-dropdown id="siteSearchDropdown" class="display-block ">
@@ -177,19 +176,25 @@
 {%- endblock htmBodyMiddlePageLayout %}
 {%- block htmBodyEndPageLayout %}
       </main>
-      <footer class="flex flex-column round-row primary-smart-border-radius" slot="main-footer">
+      <footer class="flex flex-column round-row primary-smart-border-radius margin-block">
         {% if GITHUB_ORG is defined %}
-        <wa-button variant="brand" size="large" href="https://github.com/{{ GITHUB_ORG }}/{{ SITE_NAME }}/" target="_blank">
-          This site is <b><i class="fa-brands fa-github"></i> open source</b>.
-        </wa-button>
+        <a href="https://github.com/{{ GITHUB_ORG }}/{{ SITE_NAME }}/" target="_blank">
+          <wa-card>
+            This site is <b><i class="fa-brands fa-github fa-xl"></i> open source</b>
+          </wa-card>
+        </a>
         {% endif %}
-        <wa-button variant="brand" size="large" id="footer-generated-by" href="https://www.computate.org/" target="_blank">
-            Generated with <b><img class="footer-img" src="{{ STATIC_BASE_URL }}/svg/computate-keys.svg" alt="Computate"/></b>.
-        </wa-button>
+        <a href="https://www.computate.org/" target="_blank" id="footer-generated-by">
+          <wa-card>
+              Generated with <b><img class="footer-img" src="{{ STATIC_BASE_URL }}/svg/computate-keys.svg" alt="Computate"/></b>
+          </wa-card>
+        </a>
         {% if SITE_POWERED_BY_URL is defined %}
-        <wa-button variant="brand" size="large" id="footer-powered-by" href="{{ SITE_POWERED_BY_URL }}" target="_blank">
-          Powered by <b><img class="footer-img" alt="Google Kubernetes Engine" src="{{ STATIC_BASE_URL }}/png/nerc-logo.png"/> {{ SITE_POWERED_BY_NAME | e }}</b>
-        </wa-button>
+        <a href="{{ SITE_POWERED_BY_URL }}" target="_blank" id="footer-powered-by">
+          <wa-card>
+            Powered by <i class="fa-brands fa-redhat fa-xl" style="color: #ff0000;"></i> <b>{{ SITE_POWERED_BY_NAME | e }}</b>
+          </wa-card>
+        </a>
         {% endif %}
       </footer>
     </wa-page>

--- a/src/main/resources/templates/en-us/search/gpu-device/GpuDeviceSearchPage.htm
+++ b/src/main/resources/templates/en-us/search/gpu-device/GpuDeviceSearchPage.htm
@@ -1,1 +1,125 @@
 {% extends "en-us/search/gpu-device/GpuDeviceGenSearchPage.htm" %}
+{%- block htmBodyMiddleGpuDevicePage %}
+<div id="notebooks-cpu"></div>
+{{ super() }}
+{%- endblock htmBodyMiddleGpuDevicePage %}
+{%- block htmScriptsGpuDevicePage %}
+{{ super() }}
+  <script type="module">
+    Promise.all([
+      customElements.whenDefined('wa-button')
+      , customElements.whenDefined('wa-input')
+    ]).then(() => {
+      var end = new Date();
+      var start = new Date(new Date().setHours(end.getHours() - 1));
+      var query = {
+        start: start.toISOString()
+        , end: end.toISOString()
+        , step: '5'
+      };
+      var cpuQuery = Object.assign({ query: 'sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="used"}[10m:5m])) / sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.cpu",type="hard"}[10m:5m])) * 100' }, query);
+      fetch( '/prom-keycloak-proxy/api/v1/query_range?' + new URLSearchParams(cpuQuery).toString() , { method: 'GET' }).then(cpuResponse => {
+        if(cpuResponse.ok) {
+          cpuResponse.json().then(function(cpuBody) {
+            var memoryQuery = Object.assign({ query: 'sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="used"}[10m:5m])) / sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.memory",type="hard"}[10m:5m])) * 100' }, query);
+            fetch( '/prom-keycloak-proxy/api/v1/query_range?' + new URLSearchParams(memoryQuery).toString() , { method: 'GET' }).then(memoryResponse => {
+              if(memoryResponse.ok) {
+                memoryResponse.json().then(function(memoryBody) {
+                  var persistentvolumeclaimsQuery = Object.assign({ query: 'sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="used"}[10m:5m])) / sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="persistentvolumeclaims",type="hard"}[10m:5m])) * 100' }, query);
+                  fetch( '/prom-keycloak-proxy/api/v1/query_range?' + new URLSearchParams(persistentvolumeclaimsQuery).toString() , { method: 'GET' }).then(persistentvolumeclaimsResponse => {
+                    if(persistentvolumeclaimsResponse.ok) {
+                      persistentvolumeclaimsResponse.json().then(function(persistentvolumeclaimsBody) {
+                        var ephemeralstorageQuery = Object.assign({ query: 'sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.ephemeral-storage",type="used"}[10m:5m])) / sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="limits.ephemeral-storage",type="hard"}[10m:5m])) * 100' }, query);
+                        fetch( '/prom-keycloak-proxy/api/v1/query_range?' + new URLSearchParams(ephemeralstorageQuery).toString() , { method: 'GET' }).then(ephemeralstorageResponse => {
+                          if(ephemeralstorageResponse.ok) {
+                            ephemeralstorageResponse.json().then(function(ephemeralstorageBody) {
+                              var requestsstorageQuery = Object.assign({ query: 'sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="used"}[10m:5m])) / sum(avg_over_time(kube_resourcequota{cluster="nerc-ocp-prod",namespace="rhods-notebooks",resource="requests.storage",type="hard"}[10m:5m])) * 100' }, query);
+                              fetch( '/prom-keycloak-proxy/api/v1/query_range?' + new URLSearchParams(requestsstorageQuery).toString() , { method: 'GET' }).then(requestsstorageResponse => {
+                                if(requestsstorageResponse.ok) {
+                                  requestsstorageResponse.json().then(function(requestsstorageBody) {
+
+                                    var traces = [];
+
+                                    var cpuValues = cpuBody.data.result[0].values;
+                                    traces.push({
+                                      x: cpuValues.map(subArray => subArray[0])
+                                      , y: cpuValues.map(subArray => subArray[1])
+                                      , mode: 'lines+markers'
+                                      , name: 'cpu in % of limits'
+                                    });
+
+                                    var memoryValues = memoryBody.data.result[0].values;
+                                    traces.push({
+                                      x: memoryValues.map(subArray => subArray[0])
+                                      , y: memoryValues.map(subArray => subArray[1])
+                                      , mode: 'lines+markers'
+                                      , name: 'memory in % of limits'
+                                    });
+
+                                    var persistentvolumeclaimsValues = persistentvolumeclaimsBody.data.result[0].values;
+                                    traces.push({
+                                      x: persistentvolumeclaimsValues.map(subArray => subArray[0])
+                                      , y: persistentvolumeclaimsValues.map(subArray => subArray[1])
+                                      , mode: 'lines+markers'
+                                      , name: 'persistent volume claims in % of limits'
+                                    });
+
+                                    var ephemeralstorageValues = ephemeralstorageBody.data.result[0].values;
+                                    traces.push({
+                                      x: ephemeralstorageValues.map(subArray => subArray[0])
+                                      , y: ephemeralstorageValues.map(subArray => subArray[1])
+                                      , mode: 'lines+markers'
+                                      , name: 'ephemeral storage in % of limits'
+                                    });
+
+                                    var requestsstorageValues = requestsstorageBody.data.result[0].values;
+                                    traces.push({
+                                      x: requestsstorageValues.map(subArray => subArray[0])
+                                      , y: requestsstorageValues.map(subArray => subArray[1])
+                                      , mode: 'lines+markers'
+                                      , name: 'requests storage in % of limits'
+                                    });
+
+                                    var layout = {
+                                      title: {text: 'used in % of limits'}
+                                    };
+                                    Plotly.newPlot('notebooks-cpu', traces, layout);
+
+                                  });
+                                } else {
+                                  console.log(response);
+                                }
+                              }).catch(response => function (response, target) {
+                                console.log(response);
+                              });
+                            });
+                          } else {
+                            console.log(response);
+                          }
+                        }).catch(response => function (response, target) {
+                          console.log(response);
+                        });
+                      });
+                    } else {
+                      console.log(response);
+                    }
+                  }).catch(response => function (response, target) {
+                    console.log(response);
+                  });
+                });
+              } else {
+                console.log(response);
+              }
+            }).catch(response => function (response, target) {
+              console.log(response);
+            });
+          });
+        } else {
+          console.log(response);
+        }
+      }).catch(response => function (response, target) {
+        console.log(response);
+      });
+    });
+  </script>
+{%- endblock htmScriptsGpuDevicePage %}

--- a/vars.yaml
+++ b/vars.yaml
@@ -195,6 +195,8 @@ DYNAMIC_PAGE_PATHS:
   - "en-us/article"
 # An optional FontAwesome Pro Kit for additional FontAwesome icons. 
 FONTAWESOME_KIT: "{{ query('kubernetes.core.k8s', kind='Secret', resource_name='font-awesome', namespace=SITE_NAMESPACE)[0].data['FONTAWESOME_KIT'] | b64decode }}"
+# A default FontAwesome style. 
+FONTAWESOME_STYLE: "fa-duotone fa-regular"
 # An optional link element to either a Shoelace web components stylesheet or a Web Awesome Backer web components stylesheet. 
 WEB_COMPONENTS_CSS: |-
   {{ query('kubernetes.core.k8s', kind='Secret', resource_name='font-awesome', namespace=SITE_NAMESPACE)[0].data['WEB_COMPONENTS_CSS'] | b64decode | default('<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/@shoelace-style/shoelace@2.18.0/cdn/themes/light.css" />') }}
@@ -257,36 +259,37 @@ ZOOKEEPER_SESSION_TIMEOUT_MILLIS: 5000
 # Solr defaults #
 #################
 
+# The namespace in OpenShift where Solr will run. 
+SOLR_NAMESPACE: "{{ lookup('env', 'SOLR_NAMESPACE') | default('solr', true) }}"
 # Whether to use SSL when connecting to Solr. 
-SOLR_SSL: true
+SOLR_SSL: "{{ (lookup('env', 'SOLR_SSL') | lower) != 'false' }}"
 # The host name to connect to Solr in OpenShift. 
-SOLR_HOST_NAME: "solr.{{ OPENSHIFT_APPS_DOMAIN }}"
+SOLR_HOST_NAME: "{{ lookup('env', 'SOLR_HOST_NAME') | default('solr.' + OPENSHIFT_APPS_DOMAIN, true) }}"
 # The default port that Solr runs. 
-SOLR_PORT: 443
+SOLR_PORT: "{{ lookup('env', 'SOLR_PORT') | default('443', true) }}"
+# The solr collection to use for the site. 
+SOLR_COLLECTION: "{{ lookup('env', 'SOLR_COLLECTION') | default(SITE_SHORT_NAME, true) }}"
+# The URL to the Solr collection. 
+SOLR_URL: "{{ ('https://' if SOLR_SSL == True else 'http://') + SOLR_HOST_NAME + ('' if SOLR_PORT == 443 else (':' + SOLR_PORT)) }}/solr/{{ SOLR_COLLECTION }}"
 # The solr pod name to connect and create Solr configsets and collections. 
 SOLR_POD_NAME: "solr-0"
-# The solr collection to use for the site. 
-SOLR_COLLECTION: "{{ SITE_SHORT_NAME }}"
 # The solr configset to use for the site. 
 SOLR_CONFIGSET: "computate"
 # The Solr admin username
 SOLR_USERNAME: admin
 # The Solr admin password
-SOLR_PASSWORD: "{{ query('kubernetes.core.k8s', kind='Secret', resource_name='solr', namespace='solr')[0].data['solr-password'] | b64decode }}"
-# The URL to the Solr collection. 
-SOLR_URL: "https://{{ SOLR_HOST_NAME }}:{{ SOLR_PORT }}/solr/{{ SOLR_COLLECTION }}"
+SOLR_PASSWORD: "{{ query('kubernetes.core.k8s', kind='Secret', resource_name='solr-secret', namespace=SOLR_NAMESPACE)[0].data['solr-password'] | b64decode }}"
+
 # Whether to use SSL when connecting to Solr. 
-SOLR_SSL_COMPUTATE: true
+SOLR_SSL_COMPUTATE: "{{ lookup('env', 'SOLR_SSL_COMPUTATE') | default(SOLR_SSL, true) | bool }}"
 # The host name to connect to Solr in OpenShift. 
-SOLR_HOST_NAME_COMPUTATE: "solr.{{ OPENSHIFT_APPS_DOMAIN }}"
+SOLR_HOST_NAME_COMPUTATE: "{{ lookup('env', 'SOLR_HOST_NAME_COMPUTATE') | default(SOLR_HOST_NAME, true) }}"
 # The default port that Solr runs. 
-SOLR_PORT_COMPUTATE: 443
+SOLR_PORT_COMPUTATE: "{{ lookup('env', 'SOLR_PORT_COMPUTATE') | default(SOLR_PORT, true) }}"
 # The solr collection to use for the site. 
-SOLR_COLLECTION_COMPUTATE: computate
-# The URL to the Solr collection for the watched Java code API. 
-SOLR_URL_COMPUTATE: "https://{{ SOLR_HOST_NAME }}:{{ SOLR_PORT }}/solr/{{ SOLR_COLLECTION_COMPUTATE }}"
-# The namespace in OpenShift where Solr will run. 
-SOLR_NAMESPACE: solr
+SOLR_COLLECTION_COMPUTATE: "{{ lookup('env', 'SOLR_COLLECTION_COMPUTATE') | default('computate', true) }}"
+# The URL to the Solr collection. 
+SOLR_URL_COMPUTATE: "{{ ('https://' if SOLR_SSL_COMPUTATE == True else 'http://') + SOLR_HOST_NAME_COMPUTATE + ('' if SOLR_PORT_COMPUTATE == 443 else (':' + SOLR_PORT_COMPUTATE)) }}/solr/{{ SOLR_COLLECTION_COMPUTATE }}"
 
 #####################
 # Database defaults #
@@ -316,7 +319,7 @@ DATABASE_DATABASE: "{{ SITE_SHORT_NAME }}"
 # The namespace in OpenShift where Keycloak will run. 
 AUTH_NAMESPACE: keycloak
 # The Auth host name. 
-AUTH_HOST_NAME: "keycloak.{{ OPENSHIFT_APPS_DOMAIN }}"
+AUTH_HOST_NAME: "keycloak.apps.obs.nerc.mghpcc.org"
 # The Auth port. 
 AUTH_PORT: 443
 # Whether the Auth server uses SSL. 
@@ -501,3 +504,18 @@ ENABLE_OPENID_CONNECT: true
 WRITE_API: true
 # Write code comments into generated code. 
 WRITE_COMMENTS: true
+
+#######################
+# prom-keycloak-proxy #
+#######################
+# Whether to use SSL when connecting to the Prometheus Keycloak Proxy. 
+PROM_KEYCLOAK_PROXY_SSL: "{{ (lookup('env', 'PROM_KEYCLOAK_PROXY_SSL') | lower) != 'false' }}"
+# The host name to connect to the Prometheus Keycloak Proxy in OpenShift. 
+PROM_KEYCLOAK_PROXY_HOST_NAME: "{{ lookup('env', 'PROM_KEYCLOAK_PROXY_HOST_NAME') | default('prom-keycloak-proxy.' + OPENSHIFT_APPS_DOMAIN, true) }}"
+# The default port that the Prometheus Keycloak Proxy runs. 
+PROM_KEYCLOAK_PROXY_PORT: "{{ lookup('env', 'PROM_KEYCLOAK_PROXY_PORT') | default('443', true) }}"
+
+###########
+# grafana #
+###########
+GRAFANA_BASE_URL: https://grafana.apps.obs.nerc.mghpcc.org


### PR DESCRIPTION
**Adding prom-keycloak-proxy metrics with same token**

This adds a /prom-keycloak-proxy API that passes the user's same access
token to the actual prom-keycloak-proxy. This allows us to create
frontend dashboards with Plotly JS that access metrics based on
fine-grain resource permissions. Users can access or be denied access to
dashboards and metrics based on their groups in Keycloak.

![image](https://github.com/user-attachments/assets/3e8af3a3-9b0e-43fd-ac7a-9353f7d939cc)
