### PR TITLE
Fix for unique solrIds across user collections

### DIFF
--- a/src/main/java/org/mghpcc/aitelemetry/model/BaseModel.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/BaseModel.java
@@ -290,6 +290,6 @@ public class BaseModel extends BaseModelGen<Object> implements ComputateBaseMode
 	 */
 	protected void _solrId(Wrap<String> w) {
 		if(pk != null)
-			w.o(getClass().getSimpleName() + "_" + pk.toString());
+			w.o(String.format("%s_%s_%s", getSiteRequest_().getConfig().getString(ComputateConfigKeys.SOLR_COLLECTION), getClass().getSimpleName(), pk.toString()));
 	}
 }

--- a/src/main/java/org/mghpcc/aitelemetry/result/BaseResult.java
+++ b/src/main/java/org/mghpcc/aitelemetry/result/BaseResult.java
@@ -258,6 +258,6 @@ public class BaseResult extends BaseResultGen<Object> implements ComputateBaseRe
 	 */
 	protected void _solrId(Wrap<String> w) {
 		String objectId = idForClass();
-		w.o(String.format("%s_%s", getClass().getSimpleName(), objectId));
+		w.o(String.format("%s_%s_%s", getSiteRequest_().getConfig().getString(ComputateConfigKeys.SOLR_COLLECTION), getClass().getSimpleName(), objectId));
 	}
 }


### PR DESCRIPTION
here are some updates to fix the problem with missing networks or other models to run in your workbench terminal:
- recreate the database: `oc exec $(oc get pod -l postgres-operator.crunchydata.com/role=master -o name) -- bash -c "psql -U postgres $DATABASE_DATABASE_aitelemetry -c 'drop schema public cascade; create schema public authorization pg_database_owner; grant all on schema public to $DATABASE_DATABASE_aitelemetry;'"`
- recreate solr collection: `curl -u "admin:$(oc get secret solr -o jsonpath={.data.solr-password} | base64 -d)" -k 'https://solr-ai-telemetry-cbca60.ap/
ps.shift.nerc.mghpcc.org/solr/^Ctelemetry-tzumainn/update?commitWithin=1000&overwrite=true&wt=json' -X POST -H 'Content-type: text/xml' --data
-raw '<delete><query>*:*</query></delete>'`
- rerun rebuild ai-telemetry API
- rerun ai-telemetry to do the imports
- the new solrId fields look like `"solrId":["aitelemetry-computate_AiCluster_1",1,"aitelemetry-computate_AiCluster_2",1,"aitelemetry-computate_AiNode_1",1`