### PR TITLE
Send DELETE scopes from import process

### DIFF
--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalnetwork/BareMetalNetworkEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalnetwork/BareMetalNetworkEnUSGenApiServiceImpl.java
@@ -532,6 +532,11 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalNetworkList(siteRequest, false, true, true).onSuccess(listBareMetalNetwork -> {
 					try {
 						BareMetalNetwork o = listBareMetalNetwork.first();
@@ -1885,6 +1890,11 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalNetworkList(siteRequest, false, true, true).onSuccess(listBareMetalNetwork -> {
 					try {
 						BareMetalNetwork o = listBareMetalNetwork.first();
@@ -2844,6 +2854,11 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalNetworkList(siteRequest, false, true, true).onSuccess(listBareMetalNetwork -> {
 					try {
 						BareMetalNetwork o = listBareMetalNetwork.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalnode/BareMetalNodeEnUSApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalnode/BareMetalNodeEnUSApiServiceImpl.java
@@ -106,6 +106,7 @@ public class BareMetalNodeEnUSApiServiceImpl extends BareMetalNodeEnUSGenApiServ
 								String nodeName = oldBareMetalNode.getNodeName();
 
 								JsonObject pageParams = new JsonObject();
+								pageParams.put("scopes", new JsonArray().add("GET").add("DELETE"));
 								pageParams.put("path", new JsonObject());
 								pageParams.put("cookie", new JsonObject());
 								pageParams.put("query", new JsonObject()

--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalnode/BareMetalNodeEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalnode/BareMetalNodeEnUSGenApiServiceImpl.java
@@ -532,6 +532,11 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalNodeList(siteRequest, false, true, true).onSuccess(listBareMetalNode -> {
 					try {
 						BareMetalNode o = listBareMetalNode.first();
@@ -1460,6 +1465,11 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalNodeList(siteRequest, false, true, true).onSuccess(listBareMetalNode -> {
 					try {
 						BareMetalNode o = listBareMetalNode.first();
@@ -2419,6 +2429,11 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalNodeList(siteRequest, false, true, true).onSuccess(listBareMetalNode -> {
 					try {
 						BareMetalNode o = listBareMetalNode.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderEnUSGenApiServiceImpl.java
@@ -549,6 +549,11 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalOrderList(siteRequest, false, true, true).onSuccess(listBareMetalOrder -> {
 					try {
 						BareMetalOrder o = listBareMetalOrder.first();
@@ -1536,6 +1541,11 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalOrderList(siteRequest, false, true, true).onSuccess(listBareMetalOrder -> {
 					try {
 						BareMetalOrder o = listBareMetalOrder.first();
@@ -2388,6 +2398,11 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalOrderList(siteRequest, false, true, true).onSuccess(listBareMetalOrder -> {
 					try {
 						BareMetalOrder o = listBareMetalOrder.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalresourceclass/BareMetalResourceClassEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalresourceclass/BareMetalResourceClassEnUSGenApiServiceImpl.java
@@ -424,6 +424,11 @@ public class BareMetalResourceClassEnUSGenApiServiceImpl extends BaseApiServiceI
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalResourceClassList(siteRequest, false, true, true).onSuccess(listBareMetalResourceClass -> {
 					try {
 						BareMetalResourceClass o = listBareMetalResourceClass.first();
@@ -1161,6 +1166,11 @@ public class BareMetalResourceClassEnUSGenApiServiceImpl extends BaseApiServiceI
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalResourceClassList(siteRequest, false, true, true).onSuccess(listBareMetalResourceClass -> {
 					try {
 						BareMetalResourceClass o = listBareMetalResourceClass.first();
@@ -2012,6 +2022,11 @@ public class BareMetalResourceClassEnUSGenApiServiceImpl extends BaseApiServiceI
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchBareMetalResourceClassList(siteRequest, false, true, true).onSuccess(listBareMetalResourceClass -> {
 					try {
 						BareMetalResourceClass o = listBareMetalResourceClass.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/cluster/AiClusterEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/cluster/AiClusterEnUSGenApiServiceImpl.java
@@ -616,6 +616,11 @@ public class AiClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchAiClusterList(siteRequest, false, true, true).onSuccess(listAiCluster -> {
 					try {
 						AiCluster o = listAiCluster.first();
@@ -1617,6 +1622,11 @@ public class AiClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchAiClusterList(siteRequest, false, true, true).onSuccess(listAiCluster -> {
 					try {
 						AiCluster o = listAiCluster.first();
@@ -2902,6 +2912,11 @@ public class AiClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchAiClusterList(siteRequest, false, true, true).onSuccess(listAiCluster -> {
 					try {
 						AiCluster o = listAiCluster.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/clusterorder/ClusterOrderEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/clusterorder/ClusterOrderEnUSGenApiServiceImpl.java
@@ -532,6 +532,11 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchClusterOrderList(siteRequest, false, true, true).onSuccess(listClusterOrder -> {
 					try {
 						ClusterOrder o = listClusterOrder.first();
@@ -1375,6 +1380,11 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchClusterOrderList(siteRequest, false, true, true).onSuccess(listClusterOrder -> {
 					try {
 						ClusterOrder o = listClusterOrder.first();
@@ -2334,6 +2344,11 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchClusterOrderList(siteRequest, false, true, true).onSuccess(listClusterOrder -> {
 					try {
 						ClusterOrder o = listClusterOrder.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/clusterrequest/ClusterRequestEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/clusterrequest/ClusterRequestEnUSGenApiServiceImpl.java
@@ -551,6 +551,11 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchClusterRequestList(siteRequest, false, true, true).onSuccess(listClusterRequest -> {
 					try {
 						ClusterRequest o = listClusterRequest.first();
@@ -720,6 +725,14 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 							}));
 						});
 						break;
+					case "setCreated":
+							o2.setCreated(jsonObject.getString(entityVar));
+							if(bParams.size() > 0)
+								bSql.append(", ");
+							bSql.append(ClusterRequest.VAR_created + "=$" + num);
+							num++;
+							bParams.add(o2.sqlCreated());
+						break;
 					case "setUserId":
 						Optional.ofNullable(jsonObject.getString(entityVar)).ifPresent(val -> {
 							futures1.add(Future.future(promise2 -> {
@@ -749,14 +762,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 								});
 							}));
 						});
-						break;
-					case "setCreated":
-							o2.setCreated(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(ClusterRequest.VAR_created + "=$" + num);
-							num++;
-							bParams.add(o2.sqlCreated());
 						break;
 					case "setArchived":
 							o2.setArchived(jsonObject.getBoolean(entityVar));
@@ -1162,6 +1167,15 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 							}));
 						});
 						break;
+					case ClusterRequest.VAR_created:
+						o2.setCreated(jsonObject.getString(entityVar));
+						if(bParams.size() > 0) {
+							bSql.append(", ");
+						}
+						bSql.append(ClusterRequest.VAR_created + "=$" + num);
+						num++;
+						bParams.add(o2.sqlCreated());
+						break;
 					case ClusterRequest.VAR_userId:
 						Optional.ofNullable(jsonObject.getString(entityVar)).ifPresent(val -> {
 							futures1.add(Future.future(promise2 -> {
@@ -1180,15 +1194,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 								});
 							}));
 						});
-						break;
-					case ClusterRequest.VAR_created:
-						o2.setCreated(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(ClusterRequest.VAR_created + "=$" + num);
-						num++;
-						bParams.add(o2.sqlCreated());
 						break;
 					case ClusterRequest.VAR_archived:
 						o2.setArchived(jsonObject.getBoolean(entityVar));
@@ -1451,6 +1456,11 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchClusterRequestList(siteRequest, false, true, true).onSuccess(listClusterRequest -> {
 					try {
 						ClusterRequest o = listClusterRequest.first();
@@ -2633,6 +2643,11 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchClusterRequestList(siteRequest, false, true, true).onSuccess(listClusterRequest -> {
 					try {
 						ClusterRequest o = listClusterRequest.first();
@@ -3483,8 +3498,8 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 
 			page.persistForClass(ClusterRequest.VAR_name, ClusterRequest.staticSetName(siteRequest2, (String)result.get(ClusterRequest.VAR_name)));
 			page.persistForClass(ClusterRequest.VAR_clusterTemplateTitle, ClusterRequest.staticSetClusterTemplateTitle(siteRequest2, (String)result.get(ClusterRequest.VAR_clusterTemplateTitle)));
-			page.persistForClass(ClusterRequest.VAR_userId, ClusterRequest.staticSetUserId(siteRequest2, (String)result.get(ClusterRequest.VAR_userId)));
 			page.persistForClass(ClusterRequest.VAR_created, ClusterRequest.staticSetCreated(siteRequest2, (String)result.get(ClusterRequest.VAR_created)));
+			page.persistForClass(ClusterRequest.VAR_userId, ClusterRequest.staticSetUserId(siteRequest2, (String)result.get(ClusterRequest.VAR_userId)));
 			page.persistForClass(ClusterRequest.VAR_archived, ClusterRequest.staticSetArchived(siteRequest2, (String)result.get(ClusterRequest.VAR_archived)));
 			page.persistForClass(ClusterRequest.VAR_sessionId, ClusterRequest.staticSetSessionId(siteRequest2, (String)result.get(ClusterRequest.VAR_sessionId)));
 			page.persistForClass(ClusterRequest.VAR_userKey, ClusterRequest.staticSetUserKey(siteRequest2, (String)result.get(ClusterRequest.VAR_userKey)));

--- a/src/main/java/org/mghpcc/aitelemetry/model/clustertemplate/ClusterTemplateEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/clustertemplate/ClusterTemplateEnUSGenApiServiceImpl.java
@@ -424,6 +424,11 @@ public class ClusterTemplateEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchClusterTemplateList(siteRequest, false, true, true).onSuccess(listClusterTemplate -> {
 					try {
 						ClusterTemplate o = listClusterTemplate.first();
@@ -1195,6 +1200,11 @@ public class ClusterTemplateEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchClusterTemplateList(siteRequest, false, true, true).onSuccess(listClusterTemplate -> {
 					try {
 						ClusterTemplate o = listClusterTemplate.first();
@@ -2046,6 +2056,11 @@ public class ClusterTemplateEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchClusterTemplateList(siteRequest, false, true, true).onSuccess(listClusterTemplate -> {
 					try {
 						ClusterTemplate o = listClusterTemplate.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/gpudevice/GpuDeviceEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/gpudevice/GpuDeviceEnUSGenApiServiceImpl.java
@@ -532,6 +532,11 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchGpuDeviceList(siteRequest, false, true, true).onSuccess(listGpuDevice -> {
 					try {
 						GpuDevice o = listGpuDevice.first();
@@ -1511,6 +1516,11 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchGpuDeviceList(siteRequest, false, true, true).onSuccess(listGpuDevice -> {
 					try {
 						GpuDevice o = listGpuDevice.first();
@@ -2630,6 +2640,11 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchGpuDeviceList(siteRequest, false, true, true).onSuccess(listGpuDevice -> {
 					try {
 						GpuDevice o = listGpuDevice.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/gpuslice/GpuSliceEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/gpuslice/GpuSliceEnUSGenApiServiceImpl.java
@@ -532,6 +532,11 @@ public class GpuSliceEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchGpuSliceList(siteRequest, false, true, true).onSuccess(listGpuSlice -> {
 					try {
 						GpuSlice o = listGpuSlice.first();
@@ -1443,6 +1448,11 @@ public class GpuSliceEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchGpuSliceList(siteRequest, false, true, true).onSuccess(listGpuSlice -> {
 					try {
 						GpuSlice o = listGpuSlice.first();
@@ -2562,6 +2572,11 @@ public class GpuSliceEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchGpuSliceList(siteRequest, false, true, true).onSuccess(listGpuSlice -> {
 					try {
 						GpuSlice o = listGpuSlice.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/managedcluster/ManagedClusterEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/managedcluster/ManagedClusterEnUSGenApiServiceImpl.java
@@ -532,6 +532,11 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchManagedClusterList(siteRequest, false, true, true).onSuccess(listManagedCluster -> {
 					try {
 						ManagedCluster o = listManagedCluster.first();
@@ -1375,6 +1380,11 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchManagedClusterList(siteRequest, false, true, true).onSuccess(listManagedCluster -> {
 					try {
 						ManagedCluster o = listManagedCluster.first();
@@ -2334,6 +2344,11 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchManagedClusterList(siteRequest, false, true, true).onSuccess(listManagedCluster -> {
 					try {
 						ManagedCluster o = listManagedCluster.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/node/AiNodeEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/node/AiNodeEnUSGenApiServiceImpl.java
@@ -616,6 +616,11 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchAiNodeList(siteRequest, false, true, true).onSuccess(listAiNode -> {
 					try {
 						AiNode o = listAiNode.first();
@@ -1634,6 +1639,11 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchAiNodeList(siteRequest, false, true, true).onSuccess(listAiNode -> {
 					try {
 						AiNode o = listAiNode.first();
@@ -2919,6 +2929,11 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchAiNodeList(siteRequest, false, true, true).onSuccess(listAiNode -> {
 					try {
 						AiNode o = listAiNode.first();

--- a/src/main/java/org/mghpcc/aitelemetry/model/project/AiProjectEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/project/AiProjectEnUSGenApiServiceImpl.java
@@ -616,6 +616,11 @@ public class AiProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchAiProjectList(siteRequest, false, true, true).onSuccess(listAiProject -> {
 					try {
 						AiProject o = listAiProject.first();
@@ -1515,6 +1520,11 @@ public class AiProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchAiProjectList(siteRequest, false, true, true).onSuccess(listAiProject -> {
 					try {
 						AiProject o = listAiProject.first();
@@ -2800,6 +2810,11 @@ public class AiProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchAiProjectList(siteRequest, false, true, true).onSuccess(listAiProject -> {
 					try {
 						AiProject o = listAiProject.first();

--- a/src/main/java/org/mghpcc/aitelemetry/page/SitePageEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/page/SitePageEnUSGenApiServiceImpl.java
@@ -423,6 +423,11 @@ public class SitePageEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchSitePageList(siteRequest, false, true, true).onSuccess(listSitePage -> {
 					try {
 						SitePage o = listSitePage.first();

--- a/src/main/java/org/mghpcc/aitelemetry/user/SiteUserEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/user/SiteUserEnUSGenApiServiceImpl.java
@@ -441,6 +441,11 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 			try {
 				siteRequest.setJsonObject(body);
 				serviceRequest.getParams().getJsonObject("query").put("rows", 1);
+				Optional.ofNullable(serviceRequest.getParams().getJsonArray("scopes")).ifPresent(scopes -> {
+					scopes.stream().map(v -> v.toString()).forEach(scope -> {
+						siteRequest.addScopes(scope);
+					});
+				});
 				searchSiteUserList(siteRequest, false, true, true).onSuccess(listSiteUser -> {
 					try {
 						SiteUser o = listSiteUser.first();


### PR DESCRIPTION
Fixing a vulnerability for authorization to DELETE resources by sending the
required scopes from the import process event bus message to the API event
handler.
