### PR TITLE
Add search for resource classes in bare metal order page

### DIFF
--- a/src/gen/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderGen.java
+++ b/src/gen/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderGen.java
@@ -1061,6 +1061,8 @@ public abstract class BareMetalOrderGen<DEV> extends BaseModel {
 
 	public void siteRequestBareMetalOrder(SiteRequest siteRequest_) {
 			super.siteRequestBaseModel(siteRequest_);
+		if(networkSearch != null)
+			networkSearch.setSiteRequest_(siteRequest_);
 	}
 
 	public void siteRequestForClass(SiteRequest siteRequest_) {

--- a/src/gen/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderPageGen.java
+++ b/src/gen/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderPageGen.java
@@ -33,10 +33,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.math.RoundingMode;
 import java.util.Map;
+import org.computate.vertx.search.list.SearchList;
+import org.mghpcc.aitelemetry.model.baremetalresourceclass.BareMetalResourceClass;
+import io.vertx.core.json.JsonArray;
+import org.computate.vertx.serialize.vertx.JsonArrayDeserializer;
 import org.computate.search.wrap.Wrap;
 import io.vertx.core.Promise;
 import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
 
 /**
  * <ol>
@@ -113,6 +116,118 @@ import io.vertx.core.json.JsonArray;
 public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 	protected static final Logger LOG = LoggerFactory.getLogger(BareMetalOrderPage.class);
 
+	/////////////////////////
+	// resourceClassSearch //
+	/////////////////////////
+
+
+	/**	 The entity resourceClassSearch
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonIgnore
+	@JsonInclude(Include.NON_NULL)
+	protected SearchList<BareMetalResourceClass> resourceClassSearch;
+
+	/**	<br> The entity resourceClassSearch
+	 *  is defined as null before being initialized. 
+	 * <br><a href="https://solr.apps-crc.testing/solr/#/computate/query?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.mghpcc.aitelemetry.model.baremetalorder.BareMetalOrderPage&fq=entiteVar_enUS_indexed_string:resourceClassSearch">Find the entity resourceClassSearch in Solr</a>
+	 * <br>
+	 * @param promise is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _resourceClassSearch(Promise<SearchList<BareMetalResourceClass>> promise);
+
+	public SearchList<BareMetalResourceClass> getResourceClassSearch() {
+		return resourceClassSearch;
+	}
+
+	public void setResourceClassSearch(SearchList<BareMetalResourceClass> resourceClassSearch) {
+		this.resourceClassSearch = resourceClassSearch;
+	}
+	public static SearchList<BareMetalResourceClass> staticSetResourceClassSearch(SiteRequest siteRequest_, String o) {
+		return null;
+	}
+	protected Future<SearchList<BareMetalResourceClass>> resourceClassSearchPromise() {
+		Promise<SearchList<BareMetalResourceClass>> promise = Promise.promise();
+		Promise<SearchList<BareMetalResourceClass>> promise2 = Promise.promise();
+		_resourceClassSearch(promise2);
+		promise2.future().onSuccess(o -> {
+			if(o != null && resourceClassSearch == null) {
+				o.promiseDeepForClass(siteRequest_).onSuccess(a -> {
+					setResourceClassSearch(o);
+					promise.complete(o);
+				}).onFailure(ex -> {
+					promise.fail(ex);
+				});
+			} else {
+				promise.complete(o);
+			}
+		}).onFailure(ex -> {
+			promise.fail(ex);
+		});
+		return promise.future();
+	}
+
+	/////////////////////
+	// resourceClasses //
+	/////////////////////
+
+
+	/**	 The entity resourceClasses
+	 *	 is defined as null before being initialized. 
+	 */
+	@JsonProperty
+	@JsonDeserialize(using = JsonArrayDeserializer.class)
+	@JsonInclude(Include.NON_NULL)
+	protected JsonArray resourceClasses;
+
+	/**	<br> The entity resourceClasses
+	 *  is defined as null before being initialized. 
+	 * <br><a href="https://solr.apps-crc.testing/solr/#/computate/query?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.mghpcc.aitelemetry.model.baremetalorder.BareMetalOrderPage&fq=entiteVar_enUS_indexed_string:resourceClasses">Find the entity resourceClasses in Solr</a>
+	 * <br>
+	 * @param w is for wrapping a value to assign to this entity during initialization. 
+	 **/
+	protected abstract void _resourceClasses(Wrap<JsonArray> w);
+
+	public JsonArray getResourceClasses() {
+		return resourceClasses;
+	}
+
+	public void setResourceClasses(JsonArray resourceClasses) {
+		this.resourceClasses = resourceClasses;
+	}
+	@JsonIgnore
+	public void setResourceClasses(String o) {
+		this.resourceClasses = BareMetalOrderPage.staticSetResourceClasses(siteRequest_, o);
+	}
+	public static JsonArray staticSetResourceClasses(SiteRequest siteRequest_, String o) {
+		if(o != null) {
+				return new JsonArray(o);
+		}
+		return null;
+	}
+	protected BareMetalOrderPage resourceClassesInit() {
+		Wrap<JsonArray> resourceClassesWrap = new Wrap<JsonArray>().var("resourceClasses");
+		if(resourceClasses == null) {
+			_resourceClasses(resourceClassesWrap);
+			Optional.ofNullable(resourceClassesWrap.getO()).ifPresent(o -> {
+				setResourceClasses(o);
+			});
+		}
+		return (BareMetalOrderPage)this;
+	}
+
+	public static String staticSearchResourceClasses(SiteRequest siteRequest_, JsonArray o) {
+		return o.toString();
+	}
+
+	public static String staticSearchStrResourceClasses(SiteRequest siteRequest_, String o) {
+		return o == null ? null : o.toString();
+	}
+
+	public static String staticSearchFqResourceClasses(SiteRequest siteRequest_, String o) {
+		return BareMetalOrderPage.staticSearchResourceClasses(siteRequest_, BareMetalOrderPage.staticSetResourceClasses(siteRequest_, o)).toString();
+	}
+
 	//////////////
 	// initDeep //
 	//////////////
@@ -147,6 +262,23 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 				promise2.fail(ex);
 			}
 			return promise2.future();
+		}).compose(a -> {
+			Promise<Void> promise2 = Promise.promise();
+			resourceClassSearchPromise().onSuccess(resourceClassSearch -> {
+				promise2.complete();
+			}).onFailure(ex -> {
+				promise2.fail(ex);
+			});
+			return promise2.future();
+		}).compose(a -> {
+			Promise<Void> promise2 = Promise.promise();
+			try {
+				resourceClassesInit();
+				promise2.complete();
+			} catch(Exception ex) {
+				promise2.fail(ex);
+			}
+			return promise2.future();
 		}).onSuccess(a -> {
 			promise.complete();
 		}).onFailure(ex -> {
@@ -165,6 +297,8 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 
 	public void siteRequestBareMetalOrderPage(SiteRequest siteRequest_) {
 			super.siteRequestBareMetalOrderGenPage(siteRequest_);
+		if(resourceClassSearch != null)
+			resourceClassSearch.setSiteRequest_(siteRequest_);
 	}
 
 	public void siteRequestForClass(SiteRequest siteRequest_) {
@@ -195,6 +329,10 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 	public Object obtainBareMetalOrderPage(String var) {
 		BareMetalOrderPage oBareMetalOrderPage = (BareMetalOrderPage)this;
 		switch(var) {
+			case "resourceClassSearch":
+				return oBareMetalOrderPage.resourceClassSearch;
+			case "resourceClasses":
+				return oBareMetalOrderPage.resourceClasses;
 			default:
 				return super.obtainBareMetalOrderGenPage(var);
 		}
@@ -234,6 +372,8 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 	}
 	public static Object staticSetBareMetalOrderPage(String entityVar, SiteRequest siteRequest_, String o) {
 		switch(entityVar) {
+		case "resourceClasses":
+			return BareMetalOrderPage.staticSetResourceClasses(siteRequest_, o);
 			default:
 				return BareMetalOrderGenPage.staticSetBareMetalOrderGenPage(entityVar,  siteRequest_, o);
 		}
@@ -248,6 +388,8 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 	}
 	public static Object staticSearchBareMetalOrderPage(String entityVar, SiteRequest siteRequest_, Object o) {
 		switch(entityVar) {
+		case "resourceClasses":
+			return BareMetalOrderPage.staticSearchResourceClasses(siteRequest_, (JsonArray)o);
 			default:
 				return BareMetalOrderGenPage.staticSearchBareMetalOrderGenPage(entityVar,  siteRequest_, o);
 		}
@@ -262,6 +404,8 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 	}
 	public static String staticSearchStrBareMetalOrderPage(String entityVar, SiteRequest siteRequest_, Object o) {
 		switch(entityVar) {
+		case "resourceClasses":
+			return BareMetalOrderPage.staticSearchStrResourceClasses(siteRequest_, (String)o);
 			default:
 				return BareMetalOrderGenPage.staticSearchStrBareMetalOrderGenPage(entityVar,  siteRequest_, o);
 		}
@@ -276,6 +420,8 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 	}
 	public static String staticSearchFqBareMetalOrderPage(String entityVar, SiteRequest siteRequest_, String o) {
 		switch(entityVar) {
+		case "resourceClasses":
+			return BareMetalOrderPage.staticSearchFqResourceClasses(siteRequest_, o);
 			default:
 				return BareMetalOrderGenPage.staticSearchFqBareMetalOrderGenPage(entityVar,  siteRequest_, o);
 		}
@@ -293,7 +439,11 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 
 	public static final String CLASS_SIMPLE_NAME = "BareMetalOrderPage";
 	public static final String CLASS_CANONICAL_NAME = "org.mghpcc.aitelemetry.model.baremetalorder.BareMetalOrderPage";
+	public static final String VAR_resourceClassSearch = "resourceClassSearch";
+	public static final String VAR_resourceClasses = "resourceClasses";
 
+	public static final String DISPLAY_NAME_resourceClassSearch = "";
+	public static final String DISPLAY_NAME_resourceClasses = "";
 
 	@Override
 	public String idForClass() {
@@ -345,6 +495,10 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 	}
 	public static String displayNameBareMetalOrderPage(String var) {
 		switch(var) {
+		case VAR_resourceClassSearch:
+			return DISPLAY_NAME_resourceClassSearch;
+		case VAR_resourceClasses:
+			return DISPLAY_NAME_resourceClasses;
 		default:
 			return BareMetalOrderGenPage.displayNameBareMetalOrderGenPage(var);
 		}
@@ -359,6 +513,10 @@ public abstract class BareMetalOrderPageGen<DEV> extends BareMetalOrderGenPage {
 
 	public static String classSimpleNameBareMetalOrderPage(String var) {
 		switch(var) {
+		case VAR_resourceClassSearch:
+			return "SearchList";
+		case VAR_resourceClasses:
+			return "JsonArray";
 			default:
 				return BareMetalOrderGenPage.classSimpleNameBareMetalOrderGenPage(var);
 		}

--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderPage.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderPage.java
@@ -1,7 +1,35 @@
 package org.mghpcc.aitelemetry.model.baremetalorder;
 
+import org.computate.search.wrap.Wrap;
+import org.computate.vertx.search.list.SearchList;
+import org.mghpcc.aitelemetry.model.baremetalresourceclass.BareMetalResourceClass;
+
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
 /**
  * Promise: true
  **/
 public class BareMetalOrderPage extends BareMetalOrderPageGen<BareMetalOrderGenPage> {
+
+    /**
+     * Ignore: true
+     */
+    protected void _resourceClassSearch(Promise<SearchList<BareMetalResourceClass>> promise) {
+        SearchList<BareMetalResourceClass> l = new SearchList<>();
+        l.setC(BareMetalResourceClass.class);
+        l.q("*:*");
+        l.rows(100);
+        l.setStore(true);
+        promise.complete(l);
+    }
+
+    protected void _resourceClasses(Wrap<JsonArray> w) {
+        JsonArray array = new JsonArray();
+        resourceClassSearch.getList().stream().forEach(resourceClass -> {
+            array.add(JsonObject.mapFrom(resourceClass));
+        });
+        w.o(array);
+    }
 }

--- a/src/main/java/org/mghpcc/aitelemetry/model/managedcluster/ManagedClusterEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/managedcluster/ManagedClusterEnUSGenApiServiceImpl.java
@@ -684,14 +684,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 							num++;
 							bParams.add(o2.sqlState());
 						break;
-					case "setCreated":
-							o2.setCreated(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(ManagedCluster.VAR_created + "=$" + num);
-							num++;
-							bParams.add(o2.sqlCreated());
-						break;
 					case "setApiUrl":
 							o2.setApiUrl(jsonObject.getString(entityVar));
 							if(bParams.size() > 0)
@@ -699,6 +691,14 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 							bSql.append(ManagedCluster.VAR_apiUrl + "=$" + num);
 							num++;
 							bParams.add(o2.sqlApiUrl());
+						break;
+					case "setCreated":
+							o2.setCreated(jsonObject.getString(entityVar));
+							if(bParams.size() > 0)
+								bSql.append(", ");
+							bSql.append(ManagedCluster.VAR_created + "=$" + num);
+							num++;
+							bParams.add(o2.sqlCreated());
 						break;
 					case "setConsoleUrl":
 							o2.setConsoleUrl(jsonObject.getString(entityVar));
@@ -1097,15 +1097,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 						num++;
 						bParams.add(o2.sqlState());
 						break;
-					case ManagedCluster.VAR_created:
-						o2.setCreated(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(ManagedCluster.VAR_created + "=$" + num);
-						num++;
-						bParams.add(o2.sqlCreated());
-						break;
 					case ManagedCluster.VAR_apiUrl:
 						o2.setApiUrl(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
@@ -1114,6 +1105,15 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 						bSql.append(ManagedCluster.VAR_apiUrl + "=$" + num);
 						num++;
 						bParams.add(o2.sqlApiUrl());
+						break;
+					case ManagedCluster.VAR_created:
+						o2.setCreated(jsonObject.getString(entityVar));
+						if(bParams.size() > 0) {
+							bSql.append(", ");
+						}
+						bSql.append(ManagedCluster.VAR_created + "=$" + num);
+						num++;
+						bParams.add(o2.sqlCreated());
 						break;
 					case ManagedCluster.VAR_consoleUrl:
 						o2.setConsoleUrl(jsonObject.getString(entityVar));
@@ -3060,8 +3060,8 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 
 			page.persistForClass(ManagedCluster.VAR_id, ManagedCluster.staticSetId(siteRequest2, (String)result.get(ManagedCluster.VAR_id)));
 			page.persistForClass(ManagedCluster.VAR_state, ManagedCluster.staticSetState(siteRequest2, (String)result.get(ManagedCluster.VAR_state)));
-			page.persistForClass(ManagedCluster.VAR_created, ManagedCluster.staticSetCreated(siteRequest2, (String)result.get(ManagedCluster.VAR_created)));
 			page.persistForClass(ManagedCluster.VAR_apiUrl, ManagedCluster.staticSetApiUrl(siteRequest2, (String)result.get(ManagedCluster.VAR_apiUrl)));
+			page.persistForClass(ManagedCluster.VAR_created, ManagedCluster.staticSetCreated(siteRequest2, (String)result.get(ManagedCluster.VAR_created)));
 			page.persistForClass(ManagedCluster.VAR_consoleUrl, ManagedCluster.staticSetConsoleUrl(siteRequest2, (String)result.get(ManagedCluster.VAR_consoleUrl)));
 			page.persistForClass(ManagedCluster.VAR_archived, ManagedCluster.staticSetArchived(siteRequest2, (String)result.get(ManagedCluster.VAR_archived)));
 			page.persistForClass(ManagedCluster.VAR_sessionId, ManagedCluster.staticSetSessionId(siteRequest2, (String)result.get(ManagedCluster.VAR_sessionId)));

--- a/src/main/java/org/mghpcc/aitelemetry/model/node/AiNodeEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/node/AiNodeEnUSGenApiServiceImpl.java
@@ -768,14 +768,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 							num++;
 							bParams.add(o2.sqlNodeName());
 						break;
-					case "setNodeId":
-							o2.setNodeId(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(AiNode.VAR_nodeId + "=$" + num);
-							num++;
-							bParams.add(o2.sqlNodeId());
-						break;
 					case "setCreated":
 							o2.setCreated(jsonObject.getString(entityVar));
 							if(bParams.size() > 0)
@@ -783,6 +775,14 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 							bSql.append(AiNode.VAR_created + "=$" + num);
 							num++;
 							bParams.add(o2.sqlCreated());
+						break;
+					case "setNodeId":
+							o2.setNodeId(jsonObject.getString(entityVar));
+							if(bParams.size() > 0)
+								bSql.append(", ");
+							bSql.append(AiNode.VAR_nodeId + "=$" + num);
+							num++;
+							bParams.add(o2.sqlNodeId());
 						break;
 					case "setDescription":
 							o2.setDescription(jsonObject.getString(entityVar));
@@ -808,14 +808,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 							num++;
 							bParams.add(o2.sqlLocation());
 						break;
-					case "setGpuDevicesTotal":
-							o2.setGpuDevicesTotal(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(AiNode.VAR_gpuDevicesTotal + "=$" + num);
-							num++;
-							bParams.add(o2.sqlGpuDevicesTotal());
-						break;
 					case "setSessionId":
 							o2.setSessionId(jsonObject.getString(entityVar));
 							if(bParams.size() > 0)
@@ -824,13 +816,13 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 							num++;
 							bParams.add(o2.sqlSessionId());
 						break;
-					case "setId":
-							o2.setId(jsonObject.getString(entityVar));
+					case "setGpuDevicesTotal":
+							o2.setGpuDevicesTotal(jsonObject.getString(entityVar));
 							if(bParams.size() > 0)
 								bSql.append(", ");
-							bSql.append(AiNode.VAR_id + "=$" + num);
+							bSql.append(AiNode.VAR_gpuDevicesTotal + "=$" + num);
 							num++;
-							bParams.add(o2.sqlId());
+							bParams.add(o2.sqlGpuDevicesTotal());
 						break;
 					case "setUserKey":
 							o2.setUserKey(jsonObject.getString(entityVar));
@@ -840,6 +832,14 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 							num++;
 							bParams.add(o2.sqlUserKey());
 						break;
+					case "setId":
+							o2.setId(jsonObject.getString(entityVar));
+							if(bParams.size() > 0)
+								bSql.append(", ");
+							bSql.append(AiNode.VAR_id + "=$" + num);
+							num++;
+							bParams.add(o2.sqlId());
+						break;
 					case "setNgsildTenant":
 							o2.setNgsildTenant(jsonObject.getString(entityVar));
 							if(bParams.size() > 0)
@@ -847,14 +847,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 							bSql.append(AiNode.VAR_ngsildTenant + "=$" + num);
 							num++;
 							bParams.add(o2.sqlNgsildTenant());
-						break;
-					case "setNgsildPath":
-							o2.setNgsildPath(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(AiNode.VAR_ngsildPath + "=$" + num);
-							num++;
-							bParams.add(o2.sqlNgsildPath());
 						break;
 					case "setObjectTitle":
 							o2.setObjectTitle(jsonObject.getString(entityVar));
@@ -864,13 +856,13 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 							num++;
 							bParams.add(o2.sqlObjectTitle());
 						break;
-					case "setNgsildContext":
-							o2.setNgsildContext(jsonObject.getString(entityVar));
+					case "setNgsildPath":
+							o2.setNgsildPath(jsonObject.getString(entityVar));
 							if(bParams.size() > 0)
 								bSql.append(", ");
-							bSql.append(AiNode.VAR_ngsildContext + "=$" + num);
+							bSql.append(AiNode.VAR_ngsildPath + "=$" + num);
 							num++;
-							bParams.add(o2.sqlNgsildContext());
+							bParams.add(o2.sqlNgsildPath());
 						break;
 					case "setDisplayPage":
 							o2.setDisplayPage(jsonObject.getString(entityVar));
@@ -879,6 +871,14 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 							bSql.append(AiNode.VAR_displayPage + "=$" + num);
 							num++;
 							bParams.add(o2.sqlDisplayPage());
+						break;
+					case "setNgsildContext":
+							o2.setNgsildContext(jsonObject.getString(entityVar));
+							if(bParams.size() > 0)
+								bSql.append(", ");
+							bSql.append(AiNode.VAR_ngsildContext + "=$" + num);
+							num++;
+							bParams.add(o2.sqlNgsildContext());
 						break;
 					case "setNgsildData":
 							o2.setNgsildData(jsonObject.getJsonObject(entityVar));
@@ -1265,15 +1265,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						num++;
 						bParams.add(o2.sqlNodeName());
 						break;
-					case AiNode.VAR_nodeId:
-						o2.setNodeId(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(AiNode.VAR_nodeId + "=$" + num);
-						num++;
-						bParams.add(o2.sqlNodeId());
-						break;
 					case AiNode.VAR_created:
 						o2.setCreated(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
@@ -1282,6 +1273,15 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						bSql.append(AiNode.VAR_created + "=$" + num);
 						num++;
 						bParams.add(o2.sqlCreated());
+						break;
+					case AiNode.VAR_nodeId:
+						o2.setNodeId(jsonObject.getString(entityVar));
+						if(bParams.size() > 0) {
+							bSql.append(", ");
+						}
+						bSql.append(AiNode.VAR_nodeId + "=$" + num);
+						num++;
+						bParams.add(o2.sqlNodeId());
 						break;
 					case AiNode.VAR_description:
 						o2.setDescription(jsonObject.getString(entityVar));
@@ -1310,15 +1310,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						num++;
 						bParams.add(o2.sqlLocation());
 						break;
-					case AiNode.VAR_gpuDevicesTotal:
-						o2.setGpuDevicesTotal(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(AiNode.VAR_gpuDevicesTotal + "=$" + num);
-						num++;
-						bParams.add(o2.sqlGpuDevicesTotal());
-						break;
 					case AiNode.VAR_sessionId:
 						o2.setSessionId(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
@@ -1328,14 +1319,14 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						num++;
 						bParams.add(o2.sqlSessionId());
 						break;
-					case AiNode.VAR_id:
-						o2.setId(jsonObject.getString(entityVar));
+					case AiNode.VAR_gpuDevicesTotal:
+						o2.setGpuDevicesTotal(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
 							bSql.append(", ");
 						}
-						bSql.append(AiNode.VAR_id + "=$" + num);
+						bSql.append(AiNode.VAR_gpuDevicesTotal + "=$" + num);
 						num++;
-						bParams.add(o2.sqlId());
+						bParams.add(o2.sqlGpuDevicesTotal());
 						break;
 					case AiNode.VAR_userKey:
 						o2.setUserKey(jsonObject.getString(entityVar));
@@ -1346,6 +1337,15 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						num++;
 						bParams.add(o2.sqlUserKey());
 						break;
+					case AiNode.VAR_id:
+						o2.setId(jsonObject.getString(entityVar));
+						if(bParams.size() > 0) {
+							bSql.append(", ");
+						}
+						bSql.append(AiNode.VAR_id + "=$" + num);
+						num++;
+						bParams.add(o2.sqlId());
+						break;
 					case AiNode.VAR_ngsildTenant:
 						o2.setNgsildTenant(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
@@ -1354,15 +1354,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						bSql.append(AiNode.VAR_ngsildTenant + "=$" + num);
 						num++;
 						bParams.add(o2.sqlNgsildTenant());
-						break;
-					case AiNode.VAR_ngsildPath:
-						o2.setNgsildPath(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(AiNode.VAR_ngsildPath + "=$" + num);
-						num++;
-						bParams.add(o2.sqlNgsildPath());
 						break;
 					case AiNode.VAR_objectTitle:
 						o2.setObjectTitle(jsonObject.getString(entityVar));
@@ -1373,14 +1364,14 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						num++;
 						bParams.add(o2.sqlObjectTitle());
 						break;
-					case AiNode.VAR_ngsildContext:
-						o2.setNgsildContext(jsonObject.getString(entityVar));
+					case AiNode.VAR_ngsildPath:
+						o2.setNgsildPath(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
 							bSql.append(", ");
 						}
-						bSql.append(AiNode.VAR_ngsildContext + "=$" + num);
+						bSql.append(AiNode.VAR_ngsildPath + "=$" + num);
 						num++;
-						bParams.add(o2.sqlNgsildContext());
+						bParams.add(o2.sqlNgsildPath());
 						break;
 					case AiNode.VAR_displayPage:
 						o2.setDisplayPage(jsonObject.getString(entityVar));
@@ -1390,6 +1381,15 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						bSql.append(AiNode.VAR_displayPage + "=$" + num);
 						num++;
 						bParams.add(o2.sqlDisplayPage());
+						break;
+					case AiNode.VAR_ngsildContext:
+						o2.setNgsildContext(jsonObject.getString(entityVar));
+						if(bParams.size() > 0) {
+							bSql.append(", ");
+						}
+						bSql.append(AiNode.VAR_ngsildContext + "=$" + num);
+						num++;
+						bParams.add(o2.sqlNgsildContext());
 						break;
 					case AiNode.VAR_ngsildData:
 						o2.setNgsildData(jsonObject.getJsonObject(entityVar));
@@ -3645,20 +3645,20 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 
 			page.persistForClass(AiNode.VAR_clusterName, AiNode.staticSetClusterName(siteRequest2, (String)result.get(AiNode.VAR_clusterName)));
 			page.persistForClass(AiNode.VAR_nodeName, AiNode.staticSetNodeName(siteRequest2, (String)result.get(AiNode.VAR_nodeName)));
-			page.persistForClass(AiNode.VAR_nodeId, AiNode.staticSetNodeId(siteRequest2, (String)result.get(AiNode.VAR_nodeId)));
 			page.persistForClass(AiNode.VAR_created, AiNode.staticSetCreated(siteRequest2, (String)result.get(AiNode.VAR_created)));
+			page.persistForClass(AiNode.VAR_nodeId, AiNode.staticSetNodeId(siteRequest2, (String)result.get(AiNode.VAR_nodeId)));
 			page.persistForClass(AiNode.VAR_description, AiNode.staticSetDescription(siteRequest2, (String)result.get(AiNode.VAR_description)));
 			page.persistForClass(AiNode.VAR_archived, AiNode.staticSetArchived(siteRequest2, (String)result.get(AiNode.VAR_archived)));
 			page.persistForClass(AiNode.VAR_location, AiNode.staticSetLocation(siteRequest2, (String)result.get(AiNode.VAR_location)));
-			page.persistForClass(AiNode.VAR_gpuDevicesTotal, AiNode.staticSetGpuDevicesTotal(siteRequest2, (String)result.get(AiNode.VAR_gpuDevicesTotal)));
 			page.persistForClass(AiNode.VAR_sessionId, AiNode.staticSetSessionId(siteRequest2, (String)result.get(AiNode.VAR_sessionId)));
-			page.persistForClass(AiNode.VAR_id, AiNode.staticSetId(siteRequest2, (String)result.get(AiNode.VAR_id)));
+			page.persistForClass(AiNode.VAR_gpuDevicesTotal, AiNode.staticSetGpuDevicesTotal(siteRequest2, (String)result.get(AiNode.VAR_gpuDevicesTotal)));
 			page.persistForClass(AiNode.VAR_userKey, AiNode.staticSetUserKey(siteRequest2, (String)result.get(AiNode.VAR_userKey)));
+			page.persistForClass(AiNode.VAR_id, AiNode.staticSetId(siteRequest2, (String)result.get(AiNode.VAR_id)));
 			page.persistForClass(AiNode.VAR_ngsildTenant, AiNode.staticSetNgsildTenant(siteRequest2, (String)result.get(AiNode.VAR_ngsildTenant)));
-			page.persistForClass(AiNode.VAR_ngsildPath, AiNode.staticSetNgsildPath(siteRequest2, (String)result.get(AiNode.VAR_ngsildPath)));
 			page.persistForClass(AiNode.VAR_objectTitle, AiNode.staticSetObjectTitle(siteRequest2, (String)result.get(AiNode.VAR_objectTitle)));
-			page.persistForClass(AiNode.VAR_ngsildContext, AiNode.staticSetNgsildContext(siteRequest2, (String)result.get(AiNode.VAR_ngsildContext)));
+			page.persistForClass(AiNode.VAR_ngsildPath, AiNode.staticSetNgsildPath(siteRequest2, (String)result.get(AiNode.VAR_ngsildPath)));
 			page.persistForClass(AiNode.VAR_displayPage, AiNode.staticSetDisplayPage(siteRequest2, (String)result.get(AiNode.VAR_displayPage)));
+			page.persistForClass(AiNode.VAR_ngsildContext, AiNode.staticSetNgsildContext(siteRequest2, (String)result.get(AiNode.VAR_ngsildContext)));
 			page.persistForClass(AiNode.VAR_ngsildData, AiNode.staticSetNgsildData(siteRequest2, (String)result.get(AiNode.VAR_ngsildData)));
 
 			page.promiseDeepForClass((SiteRequest)siteRequest).onSuccess(a -> {

--- a/src/main/java/org/mghpcc/aitelemetry/model/project/AiProjectEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/project/AiProjectEnUSGenApiServiceImpl.java
@@ -784,14 +784,6 @@ public class AiProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 							num++;
 							bParams.add(o2.sqlProjectId());
 						break;
-					case "setDescription":
-							o2.setDescription(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(AiProject.VAR_description + "=$" + num);
-							num++;
-							bParams.add(o2.sqlDescription());
-						break;
 					case "setArchived":
 							o2.setArchived(jsonObject.getBoolean(entityVar));
 							if(bParams.size() > 0)
@@ -799,6 +791,14 @@ public class AiProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 							bSql.append(AiProject.VAR_archived + "=$" + num);
 							num++;
 							bParams.add(o2.sqlArchived());
+						break;
+					case "setDescription":
+							o2.setDescription(jsonObject.getString(entityVar));
+							if(bParams.size() > 0)
+								bSql.append(", ");
+							bSql.append(AiProject.VAR_description + "=$" + num);
+							num++;
+							bParams.add(o2.sqlDescription());
 						break;
 					case "setSessionId":
 							o2.setSessionId(jsonObject.getString(entityVar));
@@ -1227,15 +1227,6 @@ public class AiProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						num++;
 						bParams.add(o2.sqlProjectId());
 						break;
-					case AiProject.VAR_description:
-						o2.setDescription(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(AiProject.VAR_description + "=$" + num);
-						num++;
-						bParams.add(o2.sqlDescription());
-						break;
 					case AiProject.VAR_archived:
 						o2.setArchived(jsonObject.getBoolean(entityVar));
 						if(bParams.size() > 0) {
@@ -1244,6 +1235,15 @@ public class AiProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						bSql.append(AiProject.VAR_archived + "=$" + num);
 						num++;
 						bParams.add(o2.sqlArchived());
+						break;
+					case AiProject.VAR_description:
+						o2.setDescription(jsonObject.getString(entityVar));
+						if(bParams.size() > 0) {
+							bSql.append(", ");
+						}
+						bSql.append(AiProject.VAR_description + "=$" + num);
+						num++;
+						bParams.add(o2.sqlDescription());
 						break;
 					case AiProject.VAR_sessionId:
 						o2.setSessionId(jsonObject.getString(entityVar));
@@ -3530,8 +3530,8 @@ public class AiProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 			page.persistForClass(AiProject.VAR_projectName, AiProject.staticSetProjectName(siteRequest2, (String)result.get(AiProject.VAR_projectName)));
 			page.persistForClass(AiProject.VAR_created, AiProject.staticSetCreated(siteRequest2, (String)result.get(AiProject.VAR_created)));
 			page.persistForClass(AiProject.VAR_projectId, AiProject.staticSetProjectId(siteRequest2, (String)result.get(AiProject.VAR_projectId)));
-			page.persistForClass(AiProject.VAR_description, AiProject.staticSetDescription(siteRequest2, (String)result.get(AiProject.VAR_description)));
 			page.persistForClass(AiProject.VAR_archived, AiProject.staticSetArchived(siteRequest2, (String)result.get(AiProject.VAR_archived)));
+			page.persistForClass(AiProject.VAR_description, AiProject.staticSetDescription(siteRequest2, (String)result.get(AiProject.VAR_description)));
 			page.persistForClass(AiProject.VAR_sessionId, AiProject.staticSetSessionId(siteRequest2, (String)result.get(AiProject.VAR_sessionId)));
 			page.persistForClass(AiProject.VAR_userKey, AiProject.staticSetUserKey(siteRequest2, (String)result.get(AiProject.VAR_userKey)));
 			page.persistForClass(AiProject.VAR_objectTitle, AiProject.staticSetObjectTitle(siteRequest2, (String)result.get(AiProject.VAR_objectTitle)));


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/8753ccc6-df91-4cc3-8851-e99531d51c53)

Queries the available bare metal resource classes and sets the max number on the inputs for available resource classes in the Create form for bare metal orders.