### PR TITLE
Graphs for multiple projects and cluster access control

### DIFF
--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalnetwork/BareMetalNetworkEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalnetwork/BareMetalNetworkEnUSGenApiServiceImpl.java
@@ -151,7 +151,6 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNetworkList(siteRequest, false, true, false).onSuccess(listBareMetalNetwork -> {
 							response200SearchBareMetalNetwork(listBareMetalNetwork).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -316,7 +315,6 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNetworkList(siteRequest, false, true, false).onSuccess(listBareMetalNetwork -> {
 							response200GETBareMetalNetwork(listBareMetalNetwork).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -432,7 +430,6 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNetworkList(siteRequest, false, true, true).onSuccess(listBareMetalNetwork -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1115,7 +1112,6 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1824,7 +1820,6 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNetworkList(siteRequest, false, true, true).onSuccess(listBareMetalNetwork -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -2176,7 +2171,6 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2489,7 +2483,6 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNetworkList(siteRequest, false, true, false).onSuccess(listBareMetalNetwork -> {
 							response200SearchPageBareMetalNetwork(listBareMetalNetwork).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2658,7 +2651,6 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNetworkList(siteRequest, false, true, false).onSuccess(listBareMetalNetwork -> {
 							response200EditPageBareMetalNetwork(listBareMetalNetwork).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2840,7 +2832,6 @@ public class BareMetalNetworkEnUSGenApiServiceImpl extends BaseApiServiceImpl im
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNetworkList(siteRequest, false, true, true).onSuccess(listBareMetalNetwork -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalnode/BareMetalNodeEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalnode/BareMetalNodeEnUSGenApiServiceImpl.java
@@ -151,7 +151,6 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNodeList(siteRequest, false, true, false).onSuccess(listBareMetalNode -> {
 							response200SearchBareMetalNode(listBareMetalNode).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -316,7 +315,6 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNodeList(siteRequest, false, true, false).onSuccess(listBareMetalNode -> {
 							response200GETBareMetalNode(listBareMetalNode).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -432,7 +430,6 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNodeList(siteRequest, false, true, true).onSuccess(listBareMetalNode -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -915,7 +912,6 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1399,7 +1395,6 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNodeList(siteRequest, false, true, true).onSuccess(listBareMetalNode -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1751,7 +1746,6 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2064,7 +2058,6 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNodeList(siteRequest, false, true, false).onSuccess(listBareMetalNode -> {
 							response200SearchPageBareMetalNode(listBareMetalNode).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2233,7 +2226,6 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNodeList(siteRequest, false, true, false).onSuccess(listBareMetalNode -> {
 							response200EditPageBareMetalNode(listBareMetalNode).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2415,7 +2407,6 @@ public class BareMetalNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl imple
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalNodeList(siteRequest, false, true, true).onSuccess(listBareMetalNode -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalorder/BareMetalOrderEnUSGenApiServiceImpl.java
@@ -154,7 +154,6 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalOrderList(siteRequest, false, true, false).onSuccess(listBareMetalOrder -> {
 							response200SearchBareMetalOrder(listBareMetalOrder).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -320,7 +319,6 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalOrderList(siteRequest, false, true, false).onSuccess(listBareMetalOrder -> {
 							response200GETBareMetalOrder(listBareMetalOrder).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -439,7 +437,6 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalOrderList(siteRequest, false, true, true).onSuccess(listBareMetalOrder -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -972,7 +969,6 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1497,7 +1493,6 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalOrderList(siteRequest, false, true, true).onSuccess(listBareMetalOrder -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1857,7 +1852,6 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalOrderList(siteRequest, false, true, false).onSuccess(listBareMetalOrder -> {
 							response200SearchPageBareMetalOrder(listBareMetalOrder).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2027,7 +2021,6 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalOrderList(siteRequest, false, true, false).onSuccess(listBareMetalOrder -> {
 							response200EditPageBareMetalOrder(listBareMetalOrder).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2197,7 +2190,6 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalOrderList(siteRequest, false, true, false).onSuccess(listBareMetalOrder -> {
 							response200UserPageBareMetalOrder(listBareMetalOrder).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2382,7 +2374,6 @@ public class BareMetalOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalOrderList(siteRequest, false, true, true).onSuccess(listBareMetalOrder -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/baremetalresourceclass/BareMetalResourceClassEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/baremetalresourceclass/BareMetalResourceClassEnUSGenApiServiceImpl.java
@@ -356,7 +356,6 @@ public class BareMetalResourceClassEnUSGenApiServiceImpl extends BaseApiServiceI
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalResourceClassList(siteRequest, false, true, true).onSuccess(listBareMetalResourceClass -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -783,7 +782,6 @@ public class BareMetalResourceClassEnUSGenApiServiceImpl extends BaseApiServiceI
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1204,7 +1202,6 @@ public class BareMetalResourceClassEnUSGenApiServiceImpl extends BaseApiServiceI
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalResourceClassList(siteRequest, false, true, true).onSuccess(listBareMetalResourceClass -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1556,7 +1553,6 @@ public class BareMetalResourceClassEnUSGenApiServiceImpl extends BaseApiServiceI
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2000,7 +1996,6 @@ public class BareMetalResourceClassEnUSGenApiServiceImpl extends BaseApiServiceI
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalResourceClassList(siteRequest, false, true, false).onSuccess(listBareMetalResourceClass -> {
 							response200EditPageBareMetalResourceClass(listBareMetalResourceClass).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2182,7 +2177,6 @@ public class BareMetalResourceClassEnUSGenApiServiceImpl extends BaseApiServiceI
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchBareMetalResourceClassList(siteRequest, false, true, true).onSuccess(listBareMetalResourceClass -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/clusterorder/ClusterOrderEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/clusterorder/ClusterOrderEnUSGenApiServiceImpl.java
@@ -153,7 +153,6 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterOrderList(siteRequest, false, true, false).onSuccess(listClusterOrder -> {
 							response200SearchClusterOrder(listClusterOrder).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -318,7 +317,6 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterOrderList(siteRequest, false, true, false).onSuccess(listClusterOrder -> {
 							response200GETClusterOrder(listClusterOrder).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -434,7 +432,6 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterOrderList(siteRequest, false, true, true).onSuccess(listClusterOrder -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -900,7 +897,6 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1350,7 +1346,6 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterOrderList(siteRequest, false, true, true).onSuccess(listClusterOrder -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1722,7 +1717,6 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2035,7 +2029,6 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterOrderList(siteRequest, false, true, false).onSuccess(listClusterOrder -> {
 							response200SearchPageClusterOrder(listClusterOrder).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2204,7 +2197,6 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterOrderList(siteRequest, false, true, false).onSuccess(listClusterOrder -> {
 							response200EditPageClusterOrder(listClusterOrder).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2386,7 +2378,6 @@ public class ClusterOrderEnUSGenApiServiceImpl extends BaseApiServiceImpl implem
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterOrderList(siteRequest, false, true, true).onSuccess(listClusterOrder -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/clusterrequest/ClusterRequestEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/clusterrequest/ClusterRequestEnUSGenApiServiceImpl.java
@@ -156,7 +156,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterRequestList(siteRequest, false, true, false).onSuccess(listClusterRequest -> {
 							response200SearchClusterRequest(listClusterRequest).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -322,7 +321,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterRequestList(siteRequest, false, true, false).onSuccess(listClusterRequest -> {
 							response200GETClusterRequest(listClusterRequest).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -441,7 +439,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterRequestList(siteRequest, false, true, true).onSuccess(listClusterRequest -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -925,7 +922,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1380,7 +1376,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterRequestList(siteRequest, false, true, true).onSuccess(listClusterRequest -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1775,7 +1770,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2089,7 +2083,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterRequestList(siteRequest, false, true, false).onSuccess(listClusterRequest -> {
 							response200SearchPageClusterRequest(listClusterRequest).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2259,7 +2252,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterRequestList(siteRequest, false, true, false).onSuccess(listClusterRequest -> {
 							response200EditPageClusterRequest(listClusterRequest).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2429,7 +2421,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterRequestList(siteRequest, false, true, false).onSuccess(listClusterRequest -> {
 							response200UserPageClusterRequest(listClusterRequest).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2614,7 +2605,6 @@ public class ClusterRequestEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterRequestList(siteRequest, false, true, true).onSuccess(listClusterRequest -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/clustertemplate/ClusterTemplateEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/clustertemplate/ClusterTemplateEnUSGenApiServiceImpl.java
@@ -356,7 +356,6 @@ public class ClusterTemplateEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterTemplateList(siteRequest, false, true, true).onSuccess(listClusterTemplate -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -799,7 +798,6 @@ public class ClusterTemplateEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1238,7 +1236,6 @@ public class ClusterTemplateEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterTemplateList(siteRequest, false, true, true).onSuccess(listClusterTemplate -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1590,7 +1587,6 @@ public class ClusterTemplateEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2034,7 +2030,6 @@ public class ClusterTemplateEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterTemplateList(siteRequest, false, true, false).onSuccess(listClusterTemplate -> {
 							response200EditPageClusterTemplate(listClusterTemplate).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2216,7 +2211,6 @@ public class ClusterTemplateEnUSGenApiServiceImpl extends BaseApiServiceImpl imp
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchClusterTemplateList(siteRequest, false, true, true).onSuccess(listClusterTemplate -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/gpudevice/GpuDeviceEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/gpudevice/GpuDeviceEnUSGenApiServiceImpl.java
@@ -184,12 +184,12 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchGpuDeviceList(siteRequest, false, true, false).onSuccess(listGpuDevice -> {
 							response200SearchGpuDevice(listGpuDevice).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -381,12 +381,12 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchGpuDeviceList(siteRequest, false, true, false).onSuccess(listGpuDevice -> {
 							response200GETGpuDevice(listGpuDevice).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -517,6 +517,7 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("PATCH");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("PATCH")) {
@@ -534,7 +535,6 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchGpuDeviceList(siteRequest, false, true, true).onSuccess(listGpuDevice -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1165,6 +1165,7 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("POST");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("POST")) {
@@ -1182,7 +1183,6 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1786,6 +1786,7 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("DELETE");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("DELETE")) {
@@ -1803,7 +1804,6 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchGpuDeviceList(siteRequest, false, true, true).onSuccess(listGpuDevice -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -2230,6 +2230,7 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("PUT");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("PUT")) {
@@ -2247,7 +2248,6 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2589,12 +2589,12 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchGpuDeviceList(siteRequest, false, true, false).onSuccess(listGpuDevice -> {
 							response200SearchPageGpuDevice(listGpuDevice).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2814,12 +2814,12 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchGpuDeviceList(siteRequest, false, true, false).onSuccess(listGpuDevice -> {
 							response200EditPageGpuDevice(listGpuDevice).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -3015,12 +3015,12 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchGpuDeviceList(siteRequest, false, true, false).onSuccess(listGpuDevice -> {
 							response200UserPageGpuDevice(listGpuDevice).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -3217,6 +3217,7 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("DELETE");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("DELETE")) {
@@ -3234,7 +3235,6 @@ public class GpuDeviceEnUSGenApiServiceImpl extends BaseApiServiceImpl implement
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchGpuDeviceList(siteRequest, false, true, true).onSuccess(listGpuDevice -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/hub/HubEnUSApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/hub/HubEnUSApiServiceImpl.java
@@ -809,7 +809,7 @@ public class HubEnUSApiServiceImpl extends HubEnUSGenApiServiceImpl {
             Integer promKeycloakProxyPort = Integer.parseInt(config.getString(String.format("%s_%s", ConfigKeys.PROM_KEYCLOAK_PROXY_PORT, hubIdEnv)));
             String promKeycloakProxyHostName = config.getString(String.format("%s_%s", ConfigKeys.PROM_KEYCLOAK_PROXY_HOST_NAME, hubIdEnv));
             Boolean promKeycloakProxySsl = Boolean.parseBoolean(config.getString(String.format("%s_%s", ConfigKeys.PROM_KEYCLOAK_PROXY_SSL, hubIdEnv)));
-            String promKeycloakProxyUri = String.format("/api/v1/query?query=%s", urlEncode(String.format("sum by (cluster, exported_namespace) (DCGM_FI_DEV_GPU_UTIL{cluster=\"%s\"})", clusterName)));
+            String promKeycloakProxyUri = String.format("/api/v1/query?query=%s", urlEncode(String.format("sum by (cluster, exported_namespace) (sum_over_time((max_over_time(DCGM_FI_DEV_GPU_UTIL{cluster='%s', exported_namespace!=''}[1h:]) > bool 0)[31d:1d]))", clusterName)));
 
             webClient.get(promKeycloakProxyPort, promKeycloakProxyHostName, promKeycloakProxyUri).ssl(promKeycloakProxySsl)
                     .putHeader("Authorization", String.format("Bearer %s", accessToken))

--- a/src/main/java/org/mghpcc/aitelemetry/model/hub/HubEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/hub/HubEnUSGenApiServiceImpl.java
@@ -172,12 +172,12 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchHubList(siteRequest, false, true, false).onSuccess(listHub -> {
 							response200SearchHub(listHub).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -363,12 +363,12 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchHubList(siteRequest, false, true, false).onSuccess(listHub -> {
 							response200GETHub(listHub).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -493,6 +493,7 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("PATCH");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("PATCH")) {
@@ -510,7 +511,6 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchHubList(siteRequest, false, true, true).onSuccess(listHub -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -780,14 +780,6 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 							num++;
 							bParams.add(o2.sqlHubId());
 						break;
-					case "setCreated":
-							o2.setCreated(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(Hub.VAR_created + "=$" + num);
-							num++;
-							bParams.add(o2.sqlCreated());
-						break;
 					case "setHubResource":
 							o2.setHubResource(jsonObject.getString(entityVar));
 							if(bParams.size() > 0)
@@ -795,6 +787,14 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 							bSql.append(Hub.VAR_hubResource + "=$" + num);
 							num++;
 							bParams.add(o2.sqlHubResource());
+						break;
+					case "setCreated":
+							o2.setCreated(jsonObject.getString(entityVar));
+							if(bParams.size() > 0)
+								bSql.append(", ");
+							bSql.append(Hub.VAR_created + "=$" + num);
+							num++;
+							bParams.add(o2.sqlCreated());
 						break;
 					case "setPageId":
 							o2.setPageId(jsonObject.getString(entityVar));
@@ -804,14 +804,6 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 							num++;
 							bParams.add(o2.sqlPageId());
 						break;
-					case "setArchived":
-							o2.setArchived(jsonObject.getString(entityVar));
-							if(bParams.size() > 0)
-								bSql.append(", ");
-							bSql.append(Hub.VAR_archived + "=$" + num);
-							num++;
-							bParams.add(o2.sqlArchived());
-						break;
 					case "setDescription":
 							o2.setDescription(jsonObject.getString(entityVar));
 							if(bParams.size() > 0)
@@ -819,6 +811,14 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 							bSql.append(Hub.VAR_description + "=$" + num);
 							num++;
 							bParams.add(o2.sqlDescription());
+						break;
+					case "setArchived":
+							o2.setArchived(jsonObject.getString(entityVar));
+							if(bParams.size() > 0)
+								bSql.append(", ");
+							bSql.append(Hub.VAR_archived + "=$" + num);
+							num++;
+							bParams.add(o2.sqlArchived());
 						break;
 					case "setLocalClusterName":
 							o2.setLocalClusterName(jsonObject.getString(entityVar));
@@ -978,6 +978,7 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("POST");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("POST")) {
@@ -995,7 +996,6 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1254,15 +1254,6 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						num++;
 						bParams.add(o2.sqlHubId());
 						break;
-					case Hub.VAR_created:
-						o2.setCreated(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(Hub.VAR_created + "=$" + num);
-						num++;
-						bParams.add(o2.sqlCreated());
-						break;
 					case Hub.VAR_hubResource:
 						o2.setHubResource(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
@@ -1271,6 +1262,15 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						bSql.append(Hub.VAR_hubResource + "=$" + num);
 						num++;
 						bParams.add(o2.sqlHubResource());
+						break;
+					case Hub.VAR_created:
+						o2.setCreated(jsonObject.getString(entityVar));
+						if(bParams.size() > 0) {
+							bSql.append(", ");
+						}
+						bSql.append(Hub.VAR_created + "=$" + num);
+						num++;
+						bParams.add(o2.sqlCreated());
 						break;
 					case Hub.VAR_pageId:
 						o2.setPageId(jsonObject.getString(entityVar));
@@ -1281,15 +1281,6 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						num++;
 						bParams.add(o2.sqlPageId());
 						break;
-					case Hub.VAR_archived:
-						o2.setArchived(jsonObject.getString(entityVar));
-						if(bParams.size() > 0) {
-							bSql.append(", ");
-						}
-						bSql.append(Hub.VAR_archived + "=$" + num);
-						num++;
-						bParams.add(o2.sqlArchived());
-						break;
 					case Hub.VAR_description:
 						o2.setDescription(jsonObject.getString(entityVar));
 						if(bParams.size() > 0) {
@@ -1298,6 +1289,15 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						bSql.append(Hub.VAR_description + "=$" + num);
 						num++;
 						bParams.add(o2.sqlDescription());
+						break;
+					case Hub.VAR_archived:
+						o2.setArchived(jsonObject.getString(entityVar));
+						if(bParams.size() > 0) {
+							bSql.append(", ");
+						}
+						bSql.append(Hub.VAR_archived + "=$" + num);
+						num++;
+						bParams.add(o2.sqlArchived());
 						break;
 					case Hub.VAR_localClusterName:
 						o2.setLocalClusterName(jsonObject.getString(entityVar));
@@ -1461,6 +1461,7 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("DELETE");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("DELETE")) {
@@ -1478,7 +1479,6 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchHubList(siteRequest, false, true, true).onSuccess(listHub -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1839,6 +1839,7 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("PUT");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("PUT")) {
@@ -1856,7 +1857,6 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2192,12 +2192,12 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchHubList(siteRequest, false, true, false).onSuccess(listHub -> {
 							response200SearchPageHub(listHub).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2411,12 +2411,12 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchHubList(siteRequest, false, true, false).onSuccess(listHub -> {
 							response200EditPageHub(listHub).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2606,12 +2606,12 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchHubList(siteRequest, false, true, false).onSuccess(listHub -> {
 							response200DisplayPageHub(listHub).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2801,12 +2801,12 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchHubList(siteRequest, false, true, false).onSuccess(listHub -> {
 							response200UserPageHub(listHub).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2997,6 +2997,7 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("DELETE");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("DELETE")) {
@@ -3014,7 +3015,6 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchHubList(siteRequest, false, true, true).onSuccess(listHub -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -3641,7 +3641,7 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 			SiteRequest siteRequest = o.getSiteRequest_();
 			SqlConnection sqlConnection = siteRequest.getSqlConnection();
 			Long pk = o.getPk();
-			sqlConnection.preparedQuery("SELECT hubName, hubId, created, hubResource, pageId, archived, description, localClusterName, sessionId, userKey, objectTitle, displayPage FROM Hub WHERE pk=$1")
+			sqlConnection.preparedQuery("SELECT hubName, hubId, hubResource, created, pageId, description, archived, localClusterName, sessionId, userKey, objectTitle, displayPage FROM Hub WHERE pk=$1")
 					.collecting(Collectors.toList())
 					.execute(Tuple.of(pk)
 					).onSuccess(result -> {
@@ -3847,11 +3847,11 @@ public class HubEnUSGenApiServiceImpl extends BaseApiServiceImpl implements HubE
 
 			page.persistForClass(Hub.VAR_hubName, Hub.staticSetHubName(siteRequest2, (String)result.get(Hub.VAR_hubName)));
 			page.persistForClass(Hub.VAR_hubId, Hub.staticSetHubId(siteRequest2, (String)result.get(Hub.VAR_hubId)));
-			page.persistForClass(Hub.VAR_created, Hub.staticSetCreated(siteRequest2, (String)result.get(Hub.VAR_created), Optional.ofNullable(siteRequest).map(r -> r.getConfig()).map(config -> config.getString(ConfigKeys.SITE_ZONE)).map(z -> ZoneId.of(z)).orElse(ZoneId.of("UTC"))));
 			page.persistForClass(Hub.VAR_hubResource, Hub.staticSetHubResource(siteRequest2, (String)result.get(Hub.VAR_hubResource)));
+			page.persistForClass(Hub.VAR_created, Hub.staticSetCreated(siteRequest2, (String)result.get(Hub.VAR_created), Optional.ofNullable(siteRequest).map(r -> r.getConfig()).map(config -> config.getString(ConfigKeys.SITE_ZONE)).map(z -> ZoneId.of(z)).orElse(ZoneId.of("UTC"))));
 			page.persistForClass(Hub.VAR_pageId, Hub.staticSetPageId(siteRequest2, (String)result.get(Hub.VAR_pageId)));
-			page.persistForClass(Hub.VAR_archived, Hub.staticSetArchived(siteRequest2, (String)result.get(Hub.VAR_archived)));
 			page.persistForClass(Hub.VAR_description, Hub.staticSetDescription(siteRequest2, (String)result.get(Hub.VAR_description)));
+			page.persistForClass(Hub.VAR_archived, Hub.staticSetArchived(siteRequest2, (String)result.get(Hub.VAR_archived)));
 			page.persistForClass(Hub.VAR_localClusterName, Hub.staticSetLocalClusterName(siteRequest2, (String)result.get(Hub.VAR_localClusterName)));
 			page.persistForClass(Hub.VAR_sessionId, Hub.staticSetSessionId(siteRequest2, (String)result.get(Hub.VAR_sessionId)));
 			page.persistForClass(Hub.VAR_userKey, Hub.staticSetUserKey(siteRequest2, (String)result.get(Hub.VAR_userKey)));

--- a/src/main/java/org/mghpcc/aitelemetry/model/managedcluster/ManagedClusterEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/managedcluster/ManagedClusterEnUSGenApiServiceImpl.java
@@ -151,7 +151,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchManagedClusterList(siteRequest, false, true, false).onSuccess(listManagedCluster -> {
 							response200SearchManagedCluster(listManagedCluster).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -316,7 +315,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchManagedClusterList(siteRequest, false, true, false).onSuccess(listManagedCluster -> {
 							response200GETManagedCluster(listManagedCluster).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -432,7 +430,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchManagedClusterList(siteRequest, false, true, true).onSuccess(listManagedCluster -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -875,7 +872,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1314,7 +1310,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchManagedClusterList(siteRequest, false, true, true).onSuccess(listManagedCluster -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1666,7 +1661,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -1979,7 +1973,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchManagedClusterList(siteRequest, false, true, false).onSuccess(listManagedCluster -> {
 							response200DownloadManagedCluster(listManagedCluster).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2088,7 +2081,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchManagedClusterList(siteRequest, false, true, false).onSuccess(listManagedCluster -> {
 							response200SearchPageManagedCluster(listManagedCluster).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2257,7 +2249,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchManagedClusterList(siteRequest, false, true, false).onSuccess(listManagedCluster -> {
 							response200EditPageManagedCluster(listManagedCluster).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2439,7 +2430,6 @@ public class ManagedClusterEnUSGenApiServiceImpl extends BaseApiServiceImpl impl
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchManagedClusterList(siteRequest, false, true, true).onSuccess(listManagedCluster -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/node/AiNodeEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/node/AiNodeEnUSGenApiServiceImpl.java
@@ -182,12 +182,12 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchAiNodeList(siteRequest, false, true, false).onSuccess(listAiNode -> {
 							response200SearchAiNode(listAiNode).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -379,12 +379,12 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchAiNodeList(siteRequest, false, true, false).onSuccess(listAiNode -> {
 							response200GETAiNode(listAiNode).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -515,6 +515,7 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("PATCH");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("PATCH")) {
@@ -532,7 +533,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchAiNodeList(siteRequest, false, true, true).onSuccess(listAiNode -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1116,6 +1116,7 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("POST");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("POST")) {
@@ -1133,7 +1134,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1699,6 +1699,7 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("DELETE");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("DELETE")) {
@@ -1716,7 +1717,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchAiNodeList(siteRequest, false, true, true).onSuccess(listAiNode -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -2123,6 +2123,7 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("PUT");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("PUT")) {
@@ -2140,7 +2141,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2482,12 +2482,12 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchAiNodeList(siteRequest, false, true, false).onSuccess(listAiNode -> {
 							response200SearchPageAiNode(listAiNode).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2707,12 +2707,12 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchAiNodeList(siteRequest, false, true, false).onSuccess(listAiNode -> {
 							response200EditPageAiNode(listAiNode).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2908,12 +2908,12 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchAiNodeList(siteRequest, false, true, false).onSuccess(listAiNode -> {
 							response200UserPageAiNode(listAiNode).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -3110,6 +3110,7 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("DELETE");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("DELETE")) {
@@ -3127,7 +3128,6 @@ public class AiNodeEnUSGenApiServiceImpl extends BaseApiServiceImpl implements A
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchAiNodeList(siteRequest, false, true, true).onSuccess(listAiNode -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/model/project/ProjectEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/model/project/ProjectEnUSGenApiServiceImpl.java
@@ -188,12 +188,12 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchProjectList(siteRequest, false, true, false).onSuccess(listProject -> {
 							response200SearchProject(listProject).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -391,12 +391,12 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchProjectList(siteRequest, false, true, false).onSuccess(listProject -> {
 							response200GETProject(listProject).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -533,6 +533,7 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("PATCH");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("PATCH")) {
@@ -550,7 +551,6 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchProjectList(siteRequest, false, true, true).onSuccess(listProject -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -1084,6 +1084,7 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("POST");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("POST")) {
@@ -1101,7 +1102,6 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1610,6 +1610,7 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("DELETE");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("DELETE")) {
@@ -1627,7 +1628,6 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchProjectList(siteRequest, false, true, true).onSuccess(listProject -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -2040,6 +2040,7 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("PUT");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("PUT")) {
@@ -2057,7 +2058,6 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -2405,12 +2405,12 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchProjectList(siteRequest, false, true, false).onSuccess(listProject -> {
 							response200SearchPageProject(listProject).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2636,12 +2636,12 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchProjectList(siteRequest, false, true, false).onSuccess(listProject -> {
 							response200EditPageProject(listProject).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -2843,12 +2843,12 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("GET");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchProjectList(siteRequest, false, true, false).onSuccess(listProject -> {
 							response200UserPageProject(listProject).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -3051,6 +3051,7 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 						if(fqs.size() > 0) {
 							fq.add(fqs.stream().collect(Collectors.joining(" OR ")));
 							scopes.add("DELETE");
+							siteRequest.setFilteredScope(true);
 						}
 					}
 					if(authorizationDecisionResponse.failed() && !scopes.contains("DELETE")) {
@@ -3068,7 +3069,6 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchProjectList(siteRequest, false, true, true).onSuccess(listProject -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();

--- a/src/main/java/org/mghpcc/aitelemetry/page/SitePageEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/page/SitePageEnUSGenApiServiceImpl.java
@@ -356,7 +356,6 @@ public class SitePageEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchSitePageList(siteRequest, true, false, true).onSuccess(listSitePage -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -623,7 +622,6 @@ public class SitePageEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -839,7 +837,6 @@ public class SitePageEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						JsonArray jsonArray = Optional.ofNullable(siteRequest.getJsonObject()).map(o -> o.getJsonArray("list")).orElse(new JsonArray());
 						apiRequest.setRows(Long.valueOf(jsonArray.size()));
@@ -1262,7 +1259,6 @@ public class SitePageEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchSitePageList(siteRequest, false, true, false).onSuccess(listSitePage -> {
 							response200EditPageSitePage(listSitePage).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));

--- a/src/main/java/org/mghpcc/aitelemetry/user/SiteUserEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/mghpcc/aitelemetry/user/SiteUserEnUSGenApiServiceImpl.java
@@ -152,7 +152,6 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchSiteUserList(siteRequest, false, true, false).onSuccess(listSiteUser -> {
 							response200SearchSiteUser(listSiteUser).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -333,7 +332,6 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchSiteUserList(siteRequest, false, true, true).onSuccess(listSiteUser -> {
 							try {
 								ApiRequest apiRequest = new ApiRequest();
@@ -835,7 +833,6 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					} else {
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						ApiRequest apiRequest = new ApiRequest();
 						apiRequest.setRows(1L);
 						apiRequest.setNumFound(1L);
@@ -1333,7 +1330,6 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchSiteUserList(siteRequest, false, true, false).onSuccess(listSiteUser -> {
 							response200SearchPageSiteUser(listSiteUser).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));
@@ -1503,7 +1499,6 @@ public class SiteUserEnUSGenApiServiceImpl extends BaseApiServiceImpl implements
 					{
 						siteRequest.setScopes(scopes.stream().map(o -> o.toString()).collect(Collectors.toList()));
 						List<String> scopes2 = siteRequest.getScopes();
-						siteRequest.setFilteredScope(true);
 						searchSiteUserList(siteRequest, false, true, false).onSuccess(listSiteUser -> {
 							response200EditPageSiteUser(listSiteUser).onSuccess(response -> {
 								eventHandler.handle(Future.succeededFuture(response));


### PR DESCRIPTION
Graphs are now visible for multiple projects and clusters at the same time with a filtered scope. For example, if I add permissions to my user in Keycloak for GET scope to 2 cluster and 2 projects: 
<img width="580" height="493" alt="image" src="https://github.com/user-attachments/assets/4974689a-089a-4de1-82b4-538cade0a27a" />

Here is what the projects dashboard looks like 4 2 clusters, and 2 projects. Notice there are several projects visible from the nerc-ocp-test cluster, more than the 2 I was assigned to directly. 
<img width="1592" height="3561" alt="image" src="https://github.com/user-attachments/assets/04258810-630e-4d98-a3f2-2d6368d5483d" />
