### PR TITLE
accessTokenLifespan/ssoSessionIdleTimeout now 30 min. Dynamic checking for GPU and VLLM enabled metric ranges. 

### DIFF
--- a/openshift-local/cloud-setup/configmaps/configmap-cloud-setup-tasks.yaml
+++ b/openshift-local/cloud-setup/configmaps/configmap-cloud-setup-tasks.yaml
@@ -87,8 +87,8 @@ data:
         rememberMe: true
         verifyEmail: false
         loginWithEmailAllowed: false
-        accessTokenLifespan: 30
-        ssoSessionIdleTimeout: 30
+        accessTokenLifespan: 1800
+        ssoSessionIdleTimeout: 1800
 
     #- name: Configure authentication browser executions
     #  community.general.keycloak_authentication:

--- a/src/gen/java/org/computate/aitelemetry/model/project/ProjectGen.java
+++ b/src/gen/java/org/computate/aitelemetry/model/project/ProjectGen.java
@@ -1087,6 +1087,73 @@ public abstract class ProjectGen<DEV> extends BaseModel {
     return gpuEnabled;
   }
 
+	/////////////////
+  // vllmEnabled //
+	/////////////////
+
+
+  /**
+   *  The entity vllmEnabled
+   *	 is defined as null before being initialized. 
+   */
+  @JsonProperty
+  @JsonInclude(Include.NON_NULL)
+  protected Boolean vllmEnabled;
+
+  /**
+   * <br> The entity vllmEnabled
+   *  is defined as null before being initialized. 
+   * <br><a href="https://solr.apps-crc.testing/solr/#/computate/query?q=*:*&fq=partEstEntite_indexed_boolean:true&fq=classeNomCanonique_enUS_indexed_string:org.computate.aitelemetry.model.project.Project&fq=entiteVar_enUS_indexed_string:vllmEnabled">Find the entity vllmEnabled in Solr</a>
+   * <br>
+   * @param w is for wrapping a value to assign to this entity during initialization. 
+   **/
+  protected abstract void _vllmEnabled(Wrap<Boolean> w);
+
+  public Boolean getVllmEnabled() {
+    return vllmEnabled;
+  }
+
+  public void setVllmEnabled(Boolean vllmEnabled) {
+    this.vllmEnabled = vllmEnabled;
+  }
+  @JsonIgnore
+  public void setVllmEnabled(String o) {
+    this.vllmEnabled = Project.staticSetVllmEnabled(siteRequest_, o);
+  }
+  public static Boolean staticSetVllmEnabled(SiteRequest siteRequest_, String o) {
+    return Boolean.parseBoolean(o);
+  }
+  protected Project vllmEnabledInit() {
+    Wrap<Boolean> vllmEnabledWrap = new Wrap<Boolean>().var("vllmEnabled");
+    if(vllmEnabled == null) {
+      _vllmEnabled(vllmEnabledWrap);
+      Optional.ofNullable(vllmEnabledWrap.getO()).ifPresent(o -> {
+        setVllmEnabled(o);
+      });
+    }
+    return (Project)this;
+  }
+
+  public static Boolean staticSearchVllmEnabled(SiteRequest siteRequest_, Boolean o) {
+    return o;
+  }
+
+  public static String staticSearchStrVllmEnabled(SiteRequest siteRequest_, Boolean o) {
+    return o == null ? null : o.toString();
+  }
+
+  public static String staticSearchFqVllmEnabled(SiteRequest siteRequest_, String o) {
+    return Project.staticSearchVllmEnabled(siteRequest_, Project.staticSetVllmEnabled(siteRequest_, o)).toString();
+  }
+
+  public Boolean sqlVllmEnabled() {
+    return vllmEnabled;
+  }
+
+  public static Boolean staticJsonVllmEnabled(Boolean vllmEnabled) {
+    return vllmEnabled;
+  }
+
 	/////////////////////
   // podRestartCount //
 	/////////////////////
@@ -1730,6 +1797,7 @@ public abstract class ProjectGen<DEV> extends BaseModel {
         projectFieldOfScienceInit();
         projectActiveInit();
         gpuEnabledInit();
+        vllmEnabledInit();
         podRestartCountInit();
         podsRestartingInit();
         podTerminatingCountInit();
@@ -1819,6 +1887,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
         return oProject.projectActive;
       case "gpuEnabled":
         return oProject.gpuEnabled;
+      case "vllmEnabled":
+        return oProject.vllmEnabled;
       case "podRestartCount":
         return oProject.podRestartCount;
       case "podsRestarting":
@@ -1920,6 +1990,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
       return Project.staticSetProjectActive(siteRequest_, v);
     case "gpuEnabled":
       return Project.staticSetGpuEnabled(siteRequest_, v);
+    case "vllmEnabled":
+      return Project.staticSetVllmEnabled(siteRequest_, v);
     case "podRestartCount":
       return Project.staticSetPodRestartCount(siteRequest_, v);
     case "podsRestarting":
@@ -2008,6 +2080,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
       return Project.staticSearchProjectActive(siteRequest_, (Boolean)o);
     case "gpuEnabled":
       return Project.staticSearchGpuEnabled(siteRequest_, (Boolean)o);
+    case "vllmEnabled":
+      return Project.staticSearchVllmEnabled(siteRequest_, (Boolean)o);
     case "podRestartCount":
       return Project.staticSearchPodRestartCount(siteRequest_, (Integer)o);
     case "podsRestarting":
@@ -2066,6 +2140,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
       return Project.staticSearchStrProjectActive(siteRequest_, (Boolean)o);
     case "gpuEnabled":
       return Project.staticSearchStrGpuEnabled(siteRequest_, (Boolean)o);
+    case "vllmEnabled":
+      return Project.staticSearchStrVllmEnabled(siteRequest_, (Boolean)o);
     case "podRestartCount":
       return Project.staticSearchStrPodRestartCount(siteRequest_, (Integer)o);
     case "podsRestarting":
@@ -2124,6 +2200,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
       return Project.staticSearchFqProjectActive(siteRequest_, o);
     case "gpuEnabled":
       return Project.staticSearchFqGpuEnabled(siteRequest_, o);
+    case "vllmEnabled":
+      return Project.staticSearchFqVllmEnabled(siteRequest_, o);
     case "podRestartCount":
       return Project.staticSearchFqPodRestartCount(siteRequest_, o);
     case "podsRestarting":
@@ -2247,6 +2325,14 @@ public abstract class ProjectGen<DEV> extends BaseModel {
           setGpuEnabled(val == null ? null : val.toString());
         }
         saves.add("gpuEnabled");
+        return val;
+      } else if("vllmenabled".equals(varLower)) {
+        if(val instanceof Boolean) {
+          setVllmEnabled((Boolean)val);
+        } else {
+          setVllmEnabled(val == null ? null : val.toString());
+        }
+        saves.add("vllmEnabled");
         return val;
       } else if("podrestartcount".equals(varLower)) {
         if(val instanceof Integer) {
@@ -2417,6 +2503,12 @@ public abstract class ProjectGen<DEV> extends BaseModel {
           oProject.setGpuEnabled(gpuEnabled);
       }
 
+      if(saves.contains("vllmEnabled")) {
+        Boolean vllmEnabled = (Boolean)doc.get("vllmEnabled_docvalues_boolean");
+        if(vllmEnabled != null)
+          oProject.setVllmEnabled(vllmEnabled);
+      }
+
       if(saves.contains("podRestartCount")) {
         Integer podRestartCount = (Integer)doc.get("podRestartCount_docvalues_int");
         if(podRestartCount != null)
@@ -2521,6 +2613,9 @@ public abstract class ProjectGen<DEV> extends BaseModel {
     if(gpuEnabled != null) {
       doc.put("gpuEnabled_docvalues_boolean", gpuEnabled);
     }
+    if(vllmEnabled != null) {
+      doc.put("vllmEnabled_docvalues_boolean", vllmEnabled);
+    }
     if(podRestartCount != null) {
       doc.put("podRestartCount_docvalues_int", podRestartCount);
     }
@@ -2591,6 +2686,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
         return "projectActive_docvalues_boolean";
       case "gpuEnabled":
         return "gpuEnabled_docvalues_boolean";
+      case "vllmEnabled":
+        return "vllmEnabled_docvalues_boolean";
       case "podRestartCount":
         return "podRestartCount_docvalues_int";
       case "podsRestarting":
@@ -2642,6 +2739,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
         return "projectActive_docvalues_boolean";
       case "gpuEnabled":
         return "gpuEnabled_docvalues_boolean";
+      case "vllmEnabled":
+        return "vllmEnabled_docvalues_boolean";
       case "podRestartCount":
         return "podRestartCount_docvalues_int";
       case "podsRestarting":
@@ -2693,6 +2792,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
         return "projectActive";
       case "gpuEnabled_docvalues_boolean":
         return "gpuEnabled";
+      case "vllmEnabled_docvalues_boolean":
+        return "vllmEnabled";
       case "podRestartCount_docvalues_int":
         return "podRestartCount";
       case "podsRestarting_docvalues_strings":
@@ -2753,6 +2854,7 @@ public abstract class ProjectGen<DEV> extends BaseModel {
     oProject.setProjectFieldOfScience(Optional.ofNullable(doc.get("projectFieldOfScience_docvalues_string")).map(v -> v.toString()).orElse(null));
     oProject.setProjectActive(Optional.ofNullable(doc.get("projectActive_docvalues_boolean")).map(v -> v.toString()).orElse(null));
     oProject.setGpuEnabled(Optional.ofNullable(doc.get("gpuEnabled_docvalues_boolean")).map(v -> v.toString()).orElse(null));
+    oProject.setVllmEnabled(Optional.ofNullable(doc.get("vllmEnabled_docvalues_boolean")).map(v -> v.toString()).orElse(null));
     oProject.setPodRestartCount(Optional.ofNullable(doc.get("podRestartCount_docvalues_int")).map(v -> v.toString()).orElse(null));
     Optional.ofNullable((List<?>)doc.get("podsRestarting_docvalues_strings")).orElse(Arrays.asList()).stream().filter(v -> v != null).forEach(v -> {
       oProject.addPodsRestarting(Project.staticSetPodsRestarting(siteRequest, v.toString()));
@@ -2808,6 +2910,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
         apiRequest.addVars("projectActive");
       if(!Objects.equals(gpuEnabled, original.getGpuEnabled()))
         apiRequest.addVars("gpuEnabled");
+      if(!Objects.equals(vllmEnabled, original.getVllmEnabled()))
+        apiRequest.addVars("vllmEnabled");
       if(!Objects.equals(podRestartCount, original.getPodRestartCount()))
         apiRequest.addVars("podRestartCount");
       if(!Objects.equals(podsRestarting, original.getPodsRestarting()))
@@ -2849,6 +2953,7 @@ public abstract class ProjectGen<DEV> extends BaseModel {
     sb.append(Optional.ofNullable(projectFieldOfScience).map(v -> "projectFieldOfScience: \"" + v + "\"\n" ).orElse(""));
     sb.append(Optional.ofNullable(projectActive).map(v -> "projectActive: " + v + "\n").orElse(""));
     sb.append(Optional.ofNullable(gpuEnabled).map(v -> "gpuEnabled: " + v + "\n").orElse(""));
+    sb.append(Optional.ofNullable(vllmEnabled).map(v -> "vllmEnabled: " + v + "\n").orElse(""));
     sb.append(Optional.ofNullable(podRestartCount).map(v -> "podRestartCount: " + v + "\n").orElse(""));
     sb.append(Optional.ofNullable(podsRestarting).map(v -> "podsRestarting: " + v + "\n").orElse(""));
     sb.append(Optional.ofNullable(podTerminatingCount).map(v -> "podTerminatingCount: " + v + "\n").orElse(""));
@@ -2895,6 +3000,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
   public static final String SET_projectActive = "setProjectActive";
   public static final String VAR_gpuEnabled = "gpuEnabled";
   public static final String SET_gpuEnabled = "setGpuEnabled";
+  public static final String VAR_vllmEnabled = "vllmEnabled";
+  public static final String SET_vllmEnabled = "setVllmEnabled";
   public static final String VAR_podRestartCount = "podRestartCount";
   public static final String SET_podRestartCount = "setPodRestartCount";
   public static final String VAR_podsRestarting = "podsRestarting";
@@ -2937,6 +3044,7 @@ public abstract class ProjectGen<DEV> extends BaseModel {
     vars.add(VAR_projectFieldOfScience);
     vars.add(VAR_projectActive);
     vars.add(VAR_gpuEnabled);
+    vars.add(VAR_vllmEnabled);
     vars.add(VAR_podRestartCount);
     vars.add(VAR_podsRestarting);
     vars.add(VAR_podTerminatingCount);
@@ -2973,6 +3081,7 @@ public abstract class ProjectGen<DEV> extends BaseModel {
   public static final String DISPLAY_NAME_projectFieldOfScience = "field of science";
   public static final String DISPLAY_NAME_projectActive = "project active";
   public static final String DISPLAY_NAME_gpuEnabled = "GPU enabled";
+  public static final String DISPLAY_NAME_vllmEnabled = "VLLM enabled";
   public static final String DISPLAY_NAME_podRestartCount = "pod restarts";
   public static final String DISPLAY_NAME_podsRestarting = "pods restarting";
   public static final String DISPLAY_NAME_podTerminatingCount = "pods terminating";
@@ -3050,6 +3159,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
       return patch ? SET_projectActive : VAR_projectActive;
     case VAR_gpuEnabled:
       return patch ? SET_gpuEnabled : VAR_gpuEnabled;
+    case VAR_vllmEnabled:
+      return patch ? SET_vllmEnabled : VAR_vllmEnabled;
     case VAR_podRestartCount:
       return patch ? SET_podRestartCount : VAR_podRestartCount;
     case VAR_podsRestarting:
@@ -3104,6 +3215,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
       return DISPLAY_NAME_projectActive;
     case VAR_gpuEnabled:
       return DISPLAY_NAME_gpuEnabled;
+    case VAR_vllmEnabled:
+      return DISPLAY_NAME_vllmEnabled;
     case VAR_podRestartCount:
       return DISPLAY_NAME_podRestartCount;
     case VAR_podsRestarting:
@@ -3157,6 +3270,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
       return "Whether the project is active or terminated. ";
     case VAR_gpuEnabled:
       return "Whether GPUs are enabled for this project. ";
+    case VAR_vllmEnabled:
+      return "Whether there is VLLM activity for this project. ";
     case VAR_podRestartCount:
       return "The number of pod restarts in this project. ";
     case VAR_podsRestarting:
@@ -3207,6 +3322,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
     case VAR_projectActive:
       return "Boolean";
     case VAR_gpuEnabled:
+      return "Boolean";
+    case VAR_vllmEnabled:
       return "Boolean";
     case VAR_podRestartCount:
       return "Integer";
@@ -3264,6 +3381,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
       return 3;
     case VAR_gpuEnabled:
       return 3;
+    case VAR_vllmEnabled:
+      return 3;
     case VAR_podRestartCount:
       return 4;
     case VAR_podsRestarting:
@@ -3305,6 +3424,8 @@ public abstract class ProjectGen<DEV> extends BaseModel {
       return 10;
     case VAR_gpuEnabled:
       return 11;
+    case VAR_vllmEnabled:
+      return 12;
     case VAR_podRestartCount:
       return 0;
     case VAR_podsRestarting:

--- a/src/main/java/org/computate/aitelemetry/model/project/Project.java
+++ b/src/main/java/org/computate/aitelemetry/model/project/Project.java
@@ -257,6 +257,20 @@ public class Project extends ProjectGen<BaseModel> {
    * DocValues: true
    * Persist: true
    * Facet: true
+   * DisplayName: VLLM enabled
+   * Description: Whether there is VLLM activity for this project. 
+   * HtmRow: 3
+   * HtmCell: 12
+   **/
+  protected void _vllmEnabled(Wrap<Boolean> w) {
+    w.o(false);
+  }
+
+  /**
+   * {@inheritDoc}
+   * DocValues: true
+   * Persist: true
+   * Facet: true
    * DisplayName: pod restarts
    * Description: The number of pod restarts in this project. 
    * HtmRowTitleOpen: health checks

--- a/src/main/java/org/computate/aitelemetry/model/project/ProjectEnUSApiServiceImpl.java
+++ b/src/main/java/org/computate/aitelemetry/model/project/ProjectEnUSApiServiceImpl.java
@@ -62,63 +62,74 @@ import jinjava.org.jsoup.nodes.Document;
  **/
 public class ProjectEnUSApiServiceImpl extends ProjectEnUSGenApiServiceImpl {
 
-  // @Override
-  // public void editpageProjectPageInit(JsonObject ctx, ProjectPage page, SearchList<Project> listProject, Promise<Void> promise) {
-  //   String accessToken = listProject.getSiteRequest_().getUserPrincipal().getString("access_token");
-  //   Project project = listProject.first();
-  //   if(project != null) {
-  //     String hubId = project.getHubId();
-  //     String clusterName = project.getClusterName();
-  //     String projectName = project.getProjectName();
-  //     JsonObject clusterJson = new JsonObject()
-  //         .put(Cluster.VAR_hubId, hubId)
-  //         .put(Cluster.VAR_clusterName, clusterName)
-  //         ;
-  //     DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm", Locale.US);
-  //     ZonedDateTime start = page.getDefaultRangeStart();
-  //     ZonedDateTime end = page.getDefaultRangeEnd();
-  //     String facetRangeGapVal = page.getDefaultRangeGap();
-  //     String gapBackInTime = "31d";
-  //     String gap = "1d";
-  //     switch (facetRangeGapVal) {
-  //       case "+1YEAR":
-  //         gapBackInTime = String.format("%sd", Duration.between(start, end).toDays());
-  //         gap = "1d";
-  //         break;
-  //       case "+1MONTH":
-  //         gapBackInTime = String.format("%sd", Duration.between(start, end).toDays());
-  //         gap = "1d";
-  //         break;
-  //       case "+1DAY":
-  //         gapBackInTime = String.format("%sd", Duration.between(start, end).toDays());
-  //         gap = "1d";
-  //         break;
-  //       case "+1HOUR":
-  //         gapBackInTime = String.format("%sh", Duration.between(start, end).toHours());
-  //         gap = "1h";
-  //         break;
-  //       case "+1MINUTE":
-  //         gapBackInTime = String.format("%sm", Duration.between(start, end).toMinutes());
-  //         gap = "1m";
-  //         break;
-  //       default:
-  //         gap = "1d";
-  //     }
-  //     ProjectEnUSApiServiceImpl.queryGpuProjects(vertx, webClient, config, clusterJson, Project.CLASS_SIMPLE_NAME, accessToken, gapBackInTime, gap).onSuccess(gpuDevicesTotal -> {
-  //       JsonObject gpuDeviceResult = gpuDevicesTotal.stream().map(o -> (JsonObject)o).filter(metrics -> 
-  //           Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
-  //           && projectName.equals(metrics.getJsonObject("metric").getString("exported_namespace"))
-  //           ).findFirst().orElse(null);
-  //       Boolean gpuEnabled = gpuDeviceResult != null;
-  //       ctx.put(Project.VAR_gpuEnabled, gpuEnabled);
-  //       promise.complete();
-  //     }).onFailure(ex -> {
-  //       promise.fail(ex);
-  //     });
-  //   } else {
-  //     promise.complete();
-  //   }
-  // }
+  @Override
+  public void editpageProjectPageInit(JsonObject ctx, ProjectPage page, SearchList<Project> listProject, Promise<Void> promise) {
+    String accessToken = listProject.getSiteRequest_().getUserPrincipal().getString("access_token");
+    Project project = listProject.first();
+    if(project != null) {
+      String hubId = project.getHubId();
+      String clusterName = project.getClusterName();
+      String projectName = project.getProjectName();
+      JsonObject clusterJson = new JsonObject()
+          .put(Cluster.VAR_hubId, hubId)
+          .put(Cluster.VAR_clusterName, clusterName)
+          ;
+      DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm", Locale.US);
+      ZonedDateTime start = page.getDefaultRangeStart();
+      ZonedDateTime end = page.getDefaultRangeEnd();
+      String facetRangeGapVal = page.getDefaultRangeGap();
+      String gapBackInTime;
+      String gap;
+      switch (facetRangeGapVal) {
+        case "+1YEAR":
+          gapBackInTime = String.format("%sd", Duration.between(start, end).toDays());
+          gap = "1d";
+          break;
+        case "+1MONTH":
+          gapBackInTime = String.format("%sd", Duration.between(start, end).toDays());
+          gap = "1d";
+          break;
+        case "+1DAY":
+          gapBackInTime = String.format("%sd", Duration.between(start, end).toDays());
+          gap = "1d";
+          break;
+        case "+1HOUR":
+          gapBackInTime = String.format("%sh", Duration.between(start, end).toHours());
+          gap = "1h";
+          break;
+        case "+1MINUTE":
+          gapBackInTime = String.format("%sm", Duration.between(start, end).toMinutes());
+          gap = "1m";
+          break;
+        default:
+          gapBackInTime = "31d";
+          gap = "1d";
+      }
+      ProjectEnUSApiServiceImpl.queryGpuProjects(vertx, webClient, config, clusterJson, Project.CLASS_SIMPLE_NAME, accessToken, gapBackInTime, gap).onSuccess(gpuDevicesTotal -> {
+        ProjectEnUSApiServiceImpl.queryVllmProjects(vertx, webClient, config, clusterJson, Project.CLASS_SIMPLE_NAME, accessToken, gapBackInTime, gap).onSuccess(vllmTotal -> {
+          JsonObject gpuDeviceResult = gpuDevicesTotal.stream().map(o -> (JsonObject)o).filter(metrics -> 
+              Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
+              && projectName.equals(metrics.getJsonObject("metric").getString("exported_namespace"))
+              ).findFirst().orElse(null);
+          JsonObject vllmResult = vllmTotal.stream().map(o -> (JsonObject)o).filter(metrics -> 
+              Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
+              && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
+              ).findFirst().orElse(null);
+          Boolean gpuEnabled = gpuDeviceResult != null;
+          Boolean vllmEnabled = vllmResult != null;
+          ctx.put(Project.VAR_gpuEnabled, gpuEnabled);
+          ctx.put(Project.VAR_vllmEnabled, vllmEnabled);
+          promise.complete();
+        }).onFailure(ex -> {
+          promise.fail(ex);
+        });
+      }).onFailure(ex -> {
+        promise.fail(ex);
+      });
+    } else {
+      promise.complete();
+    }
+  }
 
   ////////////////////
   // Project import //
@@ -324,133 +335,144 @@ public class ProjectEnUSApiServiceImpl extends ProjectEnUSGenApiServiceImpl {
           ProjectEnUSApiServiceImpl.queryColdfrontProjects(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(coldfrontProjects -> {
             ProjectEnUSApiServiceImpl.queryNonOpenShiftProjects(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(nonOpenShiftNamespacesTotal -> {
               ProjectEnUSApiServiceImpl.queryGpuProjects(vertx, webClient, config, clusterJson, classSimpleName, accessToken, "31d", "1d").onSuccess(gpuDevicesTotal -> {
-                ProjectEnUSApiServiceImpl.queryPodRestarts(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(podRestartsResponse -> {
-                  ProjectEnUSApiServiceImpl.queryPodTerminating(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(podTerminatingResponse -> {
-                    ProjectEnUSApiServiceImpl.queryInitPodRestarts(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(initPodRestartsResponse -> {
-                      ProjectEnUSApiServiceImpl.queryPvcsFull(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(fullPvcsResponse -> {
-                        List<Future<?>> futures = new ArrayList<>();
-                        for(Integer i = 0; i < nonOpenShiftNamespacesTotal.size(); i++) {
-                          JsonObject namespaceResult = nonOpenShiftNamespacesTotal.getJsonObject(i);
-                          String clusterName = namespaceResult.getJsonObject("metric").getString("cluster");
-                          String projectName = namespaceResult.getJsonObject("metric").getString("namespace");
-                          String namespacePhaseTerminating = namespaceResult.getJsonArray("value").getString(1);
-                          Boolean namespaceTerminating = "1".equals(namespacePhaseTerminating);
+                ProjectEnUSApiServiceImpl.queryVllmProjects(vertx, webClient, config, clusterJson, classSimpleName, accessToken, "31d", "1d").onSuccess(vllmTotal -> {
+                  ProjectEnUSApiServiceImpl.queryPodRestarts(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(podRestartsResponse -> {
+                    ProjectEnUSApiServiceImpl.queryPodTerminating(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(podTerminatingResponse -> {
+                      ProjectEnUSApiServiceImpl.queryInitPodRestarts(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(initPodRestartsResponse -> {
+                        ProjectEnUSApiServiceImpl.queryPvcsFull(vertx, webClient, config, clusterJson, classSimpleName, accessToken).onSuccess(fullPvcsResponse -> {
+                          List<Future<?>> futures = new ArrayList<>();
+                          for(Integer i = 0; i < nonOpenShiftNamespacesTotal.size(); i++) {
+                            JsonObject namespaceResult = nonOpenShiftNamespacesTotal.getJsonObject(i);
+                            String clusterName = namespaceResult.getJsonObject("metric").getString("cluster");
+                            String projectName = namespaceResult.getJsonObject("metric").getString("namespace");
+                            String namespacePhaseTerminating = namespaceResult.getJsonArray("value").getString(1);
+                            Boolean namespaceTerminating = "1".equals(namespacePhaseTerminating);
 
-                          JsonObject coldfrontProject = coldfrontProjects.stream().map(o -> (JsonObject)o).filter(proj -> 
-                              Objects.equals(projectName, Optional.ofNullable(proj.getJsonObject("attributes")).map(attributes -> attributes.getString("Allocated Project ID")).orElse(null))
-                              ).findFirst().orElse(null);
+                            JsonObject coldfrontProject = coldfrontProjects.stream().map(o -> (JsonObject)o).filter(proj -> 
+                                Objects.equals(projectName, Optional.ofNullable(proj.getJsonObject("attributes")).map(attributes -> attributes.getString("Allocated Project ID")).orElse(null))
+                                ).findFirst().orElse(null);
 
-                          JsonObject gpuDeviceResult = gpuDevicesTotal.stream().map(o -> (JsonObject)o).filter(metrics -> 
-                              Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
-                              && projectName.equals(metrics.getJsonObject("metric").getString("exported_namespace"))
-                              ).findFirst().orElse(null);
+                            JsonObject gpuDeviceResult = gpuDevicesTotal.stream().map(o -> (JsonObject)o).filter(metrics -> 
+                                Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
+                                && projectName.equals(metrics.getJsonObject("metric").getString("exported_namespace"))
+                                ).findFirst().orElse(null);
 
-                          List<JsonObject> podRestartsResults = podRestartsResponse.stream().map(o -> (JsonObject)o).filter(metrics -> 
-                              Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
-                              && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
-                              ).collect(Collectors.toList());
-                          Integer podRestartCount = Optional.ofNullable(podRestartsResults).map(l -> l.size()).orElse(0);
-                          List<String> podsRestarting = Optional.ofNullable(podRestartsResults).map(l -> 
-                              l.stream().map(o -> o.getJsonObject("metric").getString("pod")).collect(Collectors.toList())
-                              ).orElse(Arrays.asList());
+                            JsonObject vllmResult = vllmTotal.stream().map(o -> (JsonObject)o).filter(metrics -> 
+                                Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
+                                && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
+                                ).findFirst().orElse(null);
 
-                          List<JsonObject> podTerminatingResults = podTerminatingResponse.stream().map(o -> (JsonObject)o).filter(metrics -> 
-                              Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
-                              && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
-                              ).collect(Collectors.toList());
-                          Integer podTerminatingCount = Optional.ofNullable(podTerminatingResults).map(l -> l.size()).orElse(0);
-                          List<String> podsTerminating = Optional.ofNullable(podTerminatingResults).map(l -> 
-                              l.stream().map(o -> o.getJsonObject("metric").getString("pod")).collect(Collectors.toList())
-                              ).orElse(Arrays.asList());
+                            List<JsonObject> podRestartsResults = podRestartsResponse.stream().map(o -> (JsonObject)o).filter(metrics -> 
+                                Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
+                                && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
+                                ).collect(Collectors.toList());
+                            Integer podRestartCount = Optional.ofNullable(podRestartsResults).map(l -> l.size()).orElse(0);
+                            List<String> podsRestarting = Optional.ofNullable(podRestartsResults).map(l -> 
+                                l.stream().map(o -> o.getJsonObject("metric").getString("pod")).collect(Collectors.toList())
+                                ).orElse(Arrays.asList());
 
-                          List<JsonObject> initPodRestartsResults = initPodRestartsResponse.stream().map(o -> (JsonObject)o).filter(metrics -> 
-                              Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
-                              && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
-                              ).collect(Collectors.toList());
-                          Integer initPodRestartCount = Optional.ofNullable(initPodRestartsResults).map(l -> l.size()).orElse(0);
-                          List<String> initPodsRestarting = Optional.ofNullable(initPodRestartsResults).map(l -> 
-                              l.stream().map(o -> o.getJsonObject("metric").getString("pod")).collect(Collectors.toList())
-                              ).orElse(Arrays.asList());
-                          Integer totalPodsRestarting = podRestartCount + initPodRestartCount;
-                          Set<String> allPodsRestarting = new HashSet<>();
-                          allPodsRestarting.addAll(podsRestarting);
-                          allPodsRestarting.addAll(initPodsRestarting);
+                            List<JsonObject> podTerminatingResults = podTerminatingResponse.stream().map(o -> (JsonObject)o).filter(metrics -> 
+                                Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
+                                && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
+                                ).collect(Collectors.toList());
+                            Integer podTerminatingCount = Optional.ofNullable(podTerminatingResults).map(l -> l.size()).orElse(0);
+                            List<String> podsTerminating = Optional.ofNullable(podTerminatingResults).map(l -> 
+                                l.stream().map(o -> o.getJsonObject("metric").getString("pod")).collect(Collectors.toList())
+                                ).orElse(Arrays.asList());
 
-                          List<JsonObject> fullPvcsResults = fullPvcsResponse.stream().map(o -> (JsonObject)o).filter(metrics -> 
-                              Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
-                              && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
-                              ).collect(Collectors.toList());
-                          Integer fullPvcsCount = Optional.ofNullable(fullPvcsResults).map(l -> l.size()).orElse(0);
-                          List<String> fullPvcs = Optional.ofNullable(fullPvcsResults).map(l -> 
-                              l.stream().map(o -> o.getJsonObject("metric").getString("persistentvolumeclaim")).collect(Collectors.toList())
-                              ).orElse(Arrays.asList());
+                            List<JsonObject> initPodRestartsResults = initPodRestartsResponse.stream().map(o -> (JsonObject)o).filter(metrics -> 
+                                Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
+                                && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
+                                ).collect(Collectors.toList());
+                            Integer initPodRestartCount = Optional.ofNullable(initPodRestartsResults).map(l -> l.size()).orElse(0);
+                            List<String> initPodsRestarting = Optional.ofNullable(initPodRestartsResults).map(l -> 
+                                l.stream().map(o -> o.getJsonObject("metric").getString("pod")).collect(Collectors.toList())
+                                ).orElse(Arrays.asList());
+                            Integer totalPodsRestarting = podRestartCount + initPodRestartCount;
+                            Set<String> allPodsRestarting = new HashSet<>();
+                            allPodsRestarting.addAll(podsRestarting);
+                            allPodsRestarting.addAll(initPodsRestarting);
 
-                          if(projectName != null) {
-                            futures.add(Future.future(promise1 -> {
-                              try {
-                                String hubResource = String.format("%s-%s", Hub.CLASS_AUTH_RESOURCE, hubId);
-                                String clusterResource = String.format("%s-%s-%s-%s", Hub.CLASS_AUTH_RESOURCE, hubId, Cluster.CLASS_AUTH_RESOURCE, Optional.ofNullable(clusterName).orElse(""));
-                                String projectResource = String.format("%s-%s-%s-%s-%s-%s", Hub.CLASS_AUTH_RESOURCE, hubId, Cluster.CLASS_AUTH_RESOURCE, Optional.ofNullable(clusterName).orElse(""), Project.CLASS_AUTH_RESOURCE, projectName);
+                            List<JsonObject> fullPvcsResults = fullPvcsResponse.stream().map(o -> (JsonObject)o).filter(metrics -> 
+                                Objects.equals(clusterName, metrics.getJsonObject("metric").getString("cluster"))
+                                && projectName.equals(metrics.getJsonObject("metric").getString("namespace"))
+                                ).collect(Collectors.toList());
+                            Integer fullPvcsCount = Optional.ofNullable(fullPvcsResults).map(l -> l.size()).orElse(0);
+                            List<String> fullPvcs = Optional.ofNullable(fullPvcsResults).map(l -> 
+                                l.stream().map(o -> o.getJsonObject("metric").getString("persistentvolumeclaim")).collect(Collectors.toList())
+                                ).orElse(Arrays.asList());
 
-                                List<String> pageTemplatePaths = new ArrayList<>();
-                                Path pagePath = Paths.get(config.getString(ComputateConfigKeys.TEMPLATE_PATH), "/en-us/user/project");
-                                if(Files.exists(pagePath)) {
-                                  try(Stream<Path> stream = Files.walk(pagePath, 1, FileVisitOption.FOLLOW_LINKS)) {
-                                    stream.filter(Files::isRegularFile).filter(p -> 
-                                        p.getFileName().toString().equals(projectResource + ".htm")
-                                        || p.getFileName().toString().equals(projectResource + ".html")
-                                        || p.getFileName().toString().equals(projectResource + ".md")
-                                        ).forEach(path -> {
-                                      pageTemplatePaths.add(path.toAbsolutePath().toString());
-                                    });
+                            if(projectName != null) {
+                              futures.add(Future.future(promise1 -> {
+                                try {
+                                  String hubResource = String.format("%s-%s", Hub.CLASS_AUTH_RESOURCE, hubId);
+                                  String clusterResource = String.format("%s-%s-%s-%s", Hub.CLASS_AUTH_RESOURCE, hubId, Cluster.CLASS_AUTH_RESOURCE, Optional.ofNullable(clusterName).orElse(""));
+                                  String projectResource = String.format("%s-%s-%s-%s-%s-%s", Hub.CLASS_AUTH_RESOURCE, hubId, Cluster.CLASS_AUTH_RESOURCE, Optional.ofNullable(clusterName).orElse(""), Project.CLASS_AUTH_RESOURCE, projectName);
+
+                                  List<String> pageTemplatePaths = new ArrayList<>();
+                                  Path pagePath = Paths.get(config.getString(ComputateConfigKeys.TEMPLATE_PATH), "/en-us/user/project");
+                                  if(Files.exists(pagePath)) {
+                                    try(Stream<Path> stream = Files.walk(pagePath, 1, FileVisitOption.FOLLOW_LINKS)) {
+                                      stream.filter(Files::isRegularFile).filter(p -> 
+                                          p.getFileName().toString().equals(projectResource + ".htm")
+                                          || p.getFileName().toString().equals(projectResource + ".html")
+                                          || p.getFileName().toString().equals(projectResource + ".md")
+                                          ).forEach(path -> {
+                                        pageTemplatePaths.add(path.toAbsolutePath().toString());
+                                      });
+                                    }
                                   }
-                                }
-                                String templatePath = pageTemplatePaths.stream().findFirst().orElse(null);
-                                SiteRequest siteRequest = new SiteRequest();
-                                siteRequest.setConfig(config);
-                                siteRequest.setWebClient(webClient);
-                                siteRequest.initDeepSiteRequest(siteRequest);
-                                Jinjava jinjava = new Jinjava();
-                                JsonObject body = new JsonObject();
-                                if(coldfrontProject != null) {
-                                  body.put(Project.VAR_description, coldfrontProject.getJsonObject("project").getString("description").replace("\r\n", " ").replace("\n", " "));
-                                  body.put(Project.VAR_projectTitle, coldfrontProject.getJsonObject("project").getString("title").replace("\r\n", " ").replace("\n", " "));
-                                  body.put(Project.VAR_projectFieldOfScience, coldfrontProject.getJsonObject("project").getString("field_of_science").replace("\r\n", " ").replace("\n", " "));
-                                  body.put(Project.VAR_projectActive, "Active".equals(coldfrontProject.getString("status")));
-                                }
-                                importPageFromFile(body, vertx, config, jinjava, siteRequest, templatePath, Project.CLASS_SIMPLE_NAME).onSuccess(a -> {
-                                  body.put(Project.VAR_pk, projectResource);
-                                  body.put(Project.VAR_hubId, hubId);
-                                  body.put(Project.VAR_hubResource, hubResource);
-                                  body.put(Project.VAR_clusterName, clusterName);
-                                  body.put(Project.VAR_clusterResource, clusterResource);
-                                  body.put(Project.VAR_projectResource, projectResource);
-                                  body.put(Project.VAR_projectName, projectName);
-                                  body.put(Project.VAR_gpuEnabled, gpuDeviceResult != null);
-                                  body.put(Project.VAR_podRestartCount, totalPodsRestarting.toString());
-                                  body.put(Project.VAR_podsRestarting, new ArrayList<>(allPodsRestarting));
-                                  body.put(Project.VAR_podTerminatingCount, podTerminatingCount.toString());
-                                  body.put(Project.VAR_podsTerminating, new ArrayList<>(podsTerminating));
-                                  body.put(Project.VAR_fullPvcsCount, fullPvcsCount.toString());
-                                  body.put(Project.VAR_fullPvcs, new ArrayList<>(fullPvcs));
-                                  body.put(Project.VAR_namespaceTerminating, namespaceTerminating);
+                                  String templatePath = pageTemplatePaths.stream().findFirst().orElse(null);
+                                  SiteRequest siteRequest = new SiteRequest();
+                                  siteRequest.setConfig(config);
+                                  siteRequest.setWebClient(webClient);
+                                  siteRequest.initDeepSiteRequest(siteRequest);
+                                  Jinjava jinjava = new Jinjava();
+                                  JsonObject body = new JsonObject();
+                                  if(coldfrontProject != null) {
+                                    body.put(Project.VAR_description, coldfrontProject.getJsonObject("project").getString("description").replace("\r\n", " ").replace("\n", " "));
+                                    body.put(Project.VAR_projectTitle, coldfrontProject.getJsonObject("project").getString("title").replace("\r\n", " ").replace("\n", " "));
+                                    body.put(Project.VAR_projectFieldOfScience, coldfrontProject.getJsonObject("project").getString("field_of_science").replace("\r\n", " ").replace("\n", " "));
+                                    body.put(Project.VAR_projectActive, "Active".equals(coldfrontProject.getString("status")));
+                                  }
+                                  importPageFromFile(body, vertx, config, jinjava, siteRequest, templatePath, Project.CLASS_SIMPLE_NAME).onSuccess(a -> {
+                                    body.put(Project.VAR_pk, projectResource);
+                                    body.put(Project.VAR_hubId, hubId);
+                                    body.put(Project.VAR_hubResource, hubResource);
+                                    body.put(Project.VAR_clusterName, clusterName);
+                                    body.put(Project.VAR_clusterResource, clusterResource);
+                                    body.put(Project.VAR_projectResource, projectResource);
+                                    body.put(Project.VAR_projectName, projectName);
+                                    body.put(Project.VAR_gpuEnabled, gpuDeviceResult != null);
+                                    body.put(Project.VAR_vllmEnabled, vllmResult != null);
+                                    body.put(Project.VAR_podRestartCount, totalPodsRestarting.toString());
+                                    body.put(Project.VAR_podsRestarting, new ArrayList<>(allPodsRestarting));
+                                    body.put(Project.VAR_podTerminatingCount, podTerminatingCount.toString());
+                                    body.put(Project.VAR_podsTerminating, new ArrayList<>(podsTerminating));
+                                    body.put(Project.VAR_fullPvcsCount, fullPvcsCount.toString());
+                                    body.put(Project.VAR_fullPvcs, new ArrayList<>(fullPvcs));
+                                    body.put(Project.VAR_namespaceTerminating, namespaceTerminating);
 
-                                  JsonObject pageParams = new JsonObject();
-                                  pageParams.put("body", body);
-                                  pageParams.put("path", new JsonObject());
-                                  pageParams.put("cookie", new JsonObject());
-                                  pageParams.put("query", new JsonObject().put("softCommit", true).put("q", "*:*").put("var", new JsonArray().add("refresh:false")));
-                                  pageParams.put("scopes", new JsonArray().add("GET").add("POST").add("PATCH").add("PUT"));
-                                  JsonObject pageContext = new JsonObject().put("params", pageParams);
-                                  JsonObject pageRequest = new JsonObject().put("context", pageContext);
+                                    JsonObject pageParams = new JsonObject();
+                                    pageParams.put("body", body);
+                                    pageParams.put("path", new JsonObject());
+                                    pageParams.put("cookie", new JsonObject());
+                                    pageParams.put("query", new JsonObject().put("softCommit", true).put("q", "*:*").put("var", new JsonArray().add("refresh:false")));
+                                    pageParams.put("scopes", new JsonArray().add("GET").add("POST").add("PATCH").add("PUT"));
+                                    JsonObject pageContext = new JsonObject().put("params", pageParams);
+                                    JsonObject pageRequest = new JsonObject().put("context", pageContext);
 
-                                  vertx.eventBus().request(classApiAddress, pageRequest, new DeliveryOptions()
-                                      .setSendTimeout(config.getLong(ComputateConfigKeys.VERTX_MAX_EVENT_LOOP_EXECUTE_TIME) * 1000)
-                                      .addHeader("action", String.format("putimport%sFuture", classSimpleName))
-                                      ).onSuccess(message -> {
-                                    ProjectEnUSApiServiceImpl.importProjectAuth(vertx, webClient, config, hubId, classSimpleName, classApiAddress, body).onSuccess(c -> {
-                                      LOG.info(String.format("Imported %s project", projectResource));
-                                      promise1.complete();
+                                    vertx.eventBus().request(classApiAddress, pageRequest, new DeliveryOptions()
+                                        .setSendTimeout(config.getLong(ComputateConfigKeys.VERTX_MAX_EVENT_LOOP_EXECUTE_TIME) * 1000)
+                                        .addHeader("action", String.format("putimport%sFuture", classSimpleName))
+                                        ).onSuccess(message -> {
+                                      ProjectEnUSApiServiceImpl.importProjectAuth(vertx, webClient, config, hubId, classSimpleName, classApiAddress, body).onSuccess(c -> {
+                                        LOG.info(String.format("Imported %s project", projectResource));
+                                        promise1.complete();
+                                      }).onFailure(ex -> {
+                                        LOG.error(String.format(importDataFail, classSimpleName), ex);
+                                        promise1.fail(ex);
+                                      });
                                     }).onFailure(ex -> {
                                       LOG.error(String.format(importDataFail, classSimpleName), ex);
                                       promise1.fail(ex);
@@ -459,19 +481,19 @@ public class ProjectEnUSApiServiceImpl extends ProjectEnUSGenApiServiceImpl {
                                     LOG.error(String.format(importDataFail, classSimpleName), ex);
                                     promise1.fail(ex);
                                   });
-                                }).onFailure(ex -> {
+                                } catch(Exception ex) {
                                   LOG.error(String.format(importDataFail, classSimpleName), ex);
                                   promise1.fail(ex);
-                                });
-                              } catch(Exception ex) {
-                                LOG.error(String.format(importDataFail, classSimpleName), ex);
-                                promise1.fail(ex);
-                              }
-                            }));
+                                }
+                              }));
+                            }
                           }
-                        }
-                        Future.all(futures).onSuccess(b -> {
-                          promise.complete();
+                          Future.all(futures).onSuccess(b -> {
+                            promise.complete();
+                          }).onFailure(ex -> {
+                            LOG.error(String.format(importDataFail, classSimpleName), ex);
+                            promise.fail(ex);
+                          });
                         }).onFailure(ex -> {
                           LOG.error(String.format(importDataFail, classSimpleName), ex);
                           promise.fail(ex);
@@ -945,6 +967,35 @@ public class ProjectEnUSApiServiceImpl extends ProjectEnUSGenApiServiceImpl {
     return promise.future();
   }
 
+  public static Future<JsonArray> queryVllmProjects(Vertx vertx, WebClient webClient, JsonObject config, JsonObject clusterJson, String classSimpleName, String accessToken, String gapBackInTime, String gap) {
+    Promise<JsonArray> promise = Promise.promise();
+    try {
+      String hubId = clusterJson.getString(Cluster.VAR_hubId);
+      String hubIdEnv = hubId.toUpperCase().replace("-", "");
+      String clusterName = clusterJson.getString(Cluster.VAR_clusterName);
+      Integer promKeycloakProxyPort = Integer.parseInt(config.getString(String.format("%s_%s", ConfigKeys.PROM_KEYCLOAK_PROXY_PORT, hubIdEnv)));
+      String promKeycloakProxyHostName = config.getString(String.format("%s_%s", ConfigKeys.PROM_KEYCLOAK_PROXY_HOST_NAME, hubIdEnv));
+      Boolean promKeycloakProxySsl = Boolean.parseBoolean(config.getString(String.format("%s_%s", ConfigKeys.PROM_KEYCLOAK_PROXY_SSL, hubIdEnv)));
+      String promKeycloakProxyUri = String.format("/api/v1/query?query=%s", urlEncode("sum by (cluster, namespace) (sum_over_time((max_over_time(vllm:e2e_request_latency_seconds_sum{" + ("openshift-local".equals(hubId) ? "" : String.format("cluster='%s', ", clusterName)) + String.format("namespace!=''}[%s:]) >= 0)[%s:%s]))", gap, gapBackInTime, gap)));
+
+      webClient.get(promKeycloakProxyPort, promKeycloakProxyHostName, promKeycloakProxyUri).ssl(promKeycloakProxySsl)
+          .putHeader("Authorization", String.format("Bearer %s", accessToken))
+          .send()
+          .expecting(HttpResponseExpectation.SC_OK)
+          .onSuccess(metricsResponse -> {
+        JsonObject metricsBody = metricsResponse.bodyAsJsonObject();
+        promise.complete(Optional.ofNullable(metricsBody.getJsonObject("data")).map(data -> data.getJsonArray("result")).orElse(new JsonArray()));
+      }).onFailure(ex -> {
+        LOG.error(String.format("Querying VLLM projects failed at %s for %s", promKeycloakProxyHostName, promKeycloakProxyUri), ex);
+        promise.fail(ex);
+      });
+    } catch(Throwable ex) {
+      LOG.error("Querying VLLM projects failed", ex);
+      promise.fail(ex);
+    }
+    return promise.future();
+  }
+
   public static Future<JsonArray> queryGpuProjects(Vertx vertx, WebClient webClient, JsonObject config, JsonObject clusterJson, String classSimpleName, String accessToken, String gapBackInTime, String gap) {
     Promise<JsonArray> promise = Promise.promise();
     try {
@@ -968,7 +1019,7 @@ public class ProjectEnUSApiServiceImpl extends ProjectEnUSGenApiServiceImpl {
         promise.fail(ex);
       });
     } catch(Throwable ex) {
-      LOG.error(String.format(importDataFail, classSimpleName), ex);
+      LOG.error("Querying GPU projects failed", ex);
       promise.fail(ex);
     }
     return promise.future();

--- a/src/main/java/org/computate/aitelemetry/model/project/ProjectEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/computate/aitelemetry/model/project/ProjectEnUSGenApiServiceImpl.java
@@ -405,19 +405,24 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
           Promise<Void> promise1 = Promise.promise();
           userpageProjectPageInit(ctx, page, listProject, promise1);
           promise1.future().onSuccess(b -> {
-            Promise<String> promise2 = Promise.promise();
-            templateUserPageProject(ctx, page, listProject, promise2);
-            promise2.future().onSuccess(renderedTemplate -> {
-              try {
-                Buffer buffer = Buffer.buffer(renderedTemplate);
-                promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
-              } catch(Throwable ex) {
-                LOG.error(String.format("response200UserPageProject failed. "), ex);
+            try {
+              Promise<String> promise2 = Promise.promise();
+              templateUserPageProject(ctx, page, listProject, promise2);
+              promise2.future().onSuccess(renderedTemplate -> {
+                try {
+                  Buffer buffer = Buffer.buffer(renderedTemplate);
+                  promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
+                } catch(Throwable ex) {
+                  LOG.error(String.format("response200UserPageProject failed. "), ex);
+                  promise.fail(ex);
+                }
+              }).onFailure(ex -> {
                 promise.fail(ex);
-              }
-            }).onFailure(ex -> {
-              promise.fail(ex);
-            });
+              });
+            } catch(Throwable ex) {
+              LOG.error(String.format("response200UserPageProject failed. "), ex);
+              promise.tryFail(ex);
+            }
           }).onFailure(ex -> {
             promise.tryFail(ex);
           });
@@ -1549,13 +1554,13 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
               num++;
               bParams.add(o2.sqlEditPage());
             break;
-          case "setPodRestartCount":
-              o2.setPodRestartCount(jsonObject.getString(entityVar));
+          case "setVllmEnabled":
+              o2.setVllmEnabled(jsonObject.getString(entityVar));
               if(bParams.size() > 0)
                 bSql.append(", ");
-              bSql.append(Project.VAR_podRestartCount + "=$" + num);
+              bSql.append(Project.VAR_vllmEnabled + "=$" + num);
               num++;
-              bParams.add(o2.sqlPodRestartCount());
+              bParams.add(o2.sqlVllmEnabled());
             break;
           case "setUserPage":
               o2.setUserPage(jsonObject.getString(entityVar));
@@ -1565,13 +1570,13 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
               num++;
               bParams.add(o2.sqlUserPage());
             break;
-          case "setPodsRestarting":
-              o2.setPodsRestarting(jsonObject.getJsonArray(entityVar));
+          case "setPodRestartCount":
+              o2.setPodRestartCount(jsonObject.getString(entityVar));
               if(bParams.size() > 0)
                 bSql.append(", ");
-              bSql.append(Project.VAR_podsRestarting + "=$" + num);
+              bSql.append(Project.VAR_podRestartCount + "=$" + num);
               num++;
-              bParams.add(o2.sqlPodsRestarting());
+              bParams.add(o2.sqlPodRestartCount());
             break;
           case "setDownload":
               o2.setDownload(jsonObject.getString(entityVar));
@@ -1580,6 +1585,14 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
               bSql.append(Project.VAR_download + "=$" + num);
               num++;
               bParams.add(o2.sqlDownload());
+            break;
+          case "setPodsRestarting":
+              o2.setPodsRestarting(jsonObject.getJsonArray(entityVar));
+              if(bParams.size() > 0)
+                bSql.append(", ");
+              bSql.append(Project.VAR_podsRestarting + "=$" + num);
+              num++;
+              bParams.add(o2.sqlPodsRestarting());
             break;
           case "setPodTerminatingCount":
               o2.setPodTerminatingCount(jsonObject.getString(entityVar));
@@ -2281,14 +2294,14 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
             num++;
             bParams.add(o2.sqlEditPage());
             break;
-          case Project.VAR_podRestartCount:
-            o2.setPodRestartCount(jsonObject.getString(entityVar));
+          case Project.VAR_vllmEnabled:
+            o2.setVllmEnabled(jsonObject.getString(entityVar));
             if(bParams.size() > 0) {
               bSql.append(", ");
             }
-            bSql.append(Project.VAR_podRestartCount + "=$" + num);
+            bSql.append(Project.VAR_vllmEnabled + "=$" + num);
             num++;
-            bParams.add(o2.sqlPodRestartCount());
+            bParams.add(o2.sqlVllmEnabled());
             break;
           case Project.VAR_userPage:
             o2.setUserPage(jsonObject.getString(entityVar));
@@ -2299,14 +2312,14 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
             num++;
             bParams.add(o2.sqlUserPage());
             break;
-          case Project.VAR_podsRestarting:
-            o2.setPodsRestarting(jsonObject.getJsonArray(entityVar));
+          case Project.VAR_podRestartCount:
+            o2.setPodRestartCount(jsonObject.getString(entityVar));
             if(bParams.size() > 0) {
               bSql.append(", ");
             }
-            bSql.append(Project.VAR_podsRestarting + "=$" + num);
+            bSql.append(Project.VAR_podRestartCount + "=$" + num);
             num++;
-            bParams.add(o2.sqlPodsRestarting());
+            bParams.add(o2.sqlPodRestartCount());
             break;
           case Project.VAR_download:
             o2.setDownload(jsonObject.getString(entityVar));
@@ -2316,6 +2329,15 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
             bSql.append(Project.VAR_download + "=$" + num);
             num++;
             bParams.add(o2.sqlDownload());
+            break;
+          case Project.VAR_podsRestarting:
+            o2.setPodsRestarting(jsonObject.getJsonArray(entityVar));
+            if(bParams.size() > 0) {
+              bSql.append(", ");
+            }
+            bSql.append(Project.VAR_podsRestarting + "=$" + num);
+            num++;
+            bParams.add(o2.sqlPodsRestarting());
             break;
           case Project.VAR_podTerminatingCount:
             o2.setPodTerminatingCount(jsonObject.getString(entityVar));
@@ -3645,19 +3667,24 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
           Promise<Void> promise1 = Promise.promise();
           searchpageProjectPageInit(ctx, page, listProject, promise1);
           promise1.future().onSuccess(b -> {
-            Promise<String> promise2 = Promise.promise();
-            templateSearchPageProject(ctx, page, listProject, promise2);
-            promise2.future().onSuccess(renderedTemplate -> {
-              try {
-                Buffer buffer = Buffer.buffer(renderedTemplate);
-                promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
-              } catch(Throwable ex) {
-                LOG.error(String.format("response200SearchPageProject failed. "), ex);
+            try {
+              Promise<String> promise2 = Promise.promise();
+              templateSearchPageProject(ctx, page, listProject, promise2);
+              promise2.future().onSuccess(renderedTemplate -> {
+                try {
+                  Buffer buffer = Buffer.buffer(renderedTemplate);
+                  promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
+                } catch(Throwable ex) {
+                  LOG.error(String.format("response200SearchPageProject failed. "), ex);
+                  promise.fail(ex);
+                }
+              }).onFailure(ex -> {
                 promise.fail(ex);
-              }
-            }).onFailure(ex -> {
-              promise.fail(ex);
-            });
+              });
+            } catch(Throwable ex) {
+              LOG.error(String.format("response200SearchPageProject failed. "), ex);
+              promise.tryFail(ex);
+            }
           }).onFailure(ex -> {
             promise.tryFail(ex);
           });
@@ -3993,19 +4020,24 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
           Promise<Void> promise1 = Promise.promise();
           editpageProjectPageInit(ctx, page, listProject, promise1);
           promise1.future().onSuccess(b -> {
-            Promise<String> promise2 = Promise.promise();
-            templateEditPageProject(ctx, page, listProject, promise2);
-            promise2.future().onSuccess(renderedTemplate -> {
-              try {
-                Buffer buffer = Buffer.buffer(renderedTemplate);
-                promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
-              } catch(Throwable ex) {
-                LOG.error(String.format("response200EditPageProject failed. "), ex);
+            try {
+              Promise<String> promise2 = Promise.promise();
+              templateEditPageProject(ctx, page, listProject, promise2);
+              promise2.future().onSuccess(renderedTemplate -> {
+                try {
+                  Buffer buffer = Buffer.buffer(renderedTemplate);
+                  promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
+                } catch(Throwable ex) {
+                  LOG.error(String.format("response200EditPageProject failed. "), ex);
+                  promise.fail(ex);
+                }
+              }).onFailure(ex -> {
                 promise.fail(ex);
-              }
-            }).onFailure(ex -> {
-              promise.fail(ex);
-            });
+              });
+            } catch(Throwable ex) {
+              LOG.error(String.format("response200EditPageProject failed. "), ex);
+              promise.tryFail(ex);
+            }
           }).onFailure(ex -> {
             promise.tryFail(ex);
           });
@@ -4886,7 +4918,7 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
       SiteRequest siteRequest = o.getSiteRequest_();
       SqlConnection sqlConnection = siteRequest.getSqlConnection();
       Long pk = o.getPk();
-      sqlConnection.preparedQuery("SELECT tenantResource, localClusterName, created, hubId, hubResource, archived, clusterName, clusterResource, projectName, projectResource, sessionId, userKey, projectTitle, description, projectFieldOfScience, objectTitle, projectActive, displayPage, gpuEnabled, editPage, podRestartCount, userPage, podsRestarting, download, podTerminatingCount, podsTerminating, fullPvcsCount, fullPvcs, namespaceTerminating, statusPageTemplateUri FROM Project WHERE pk=$1")
+      sqlConnection.preparedQuery("SELECT tenantResource, localClusterName, created, hubId, hubResource, archived, clusterName, clusterResource, projectName, projectResource, sessionId, userKey, projectTitle, description, projectFieldOfScience, objectTitle, projectActive, displayPage, gpuEnabled, editPage, vllmEnabled, userPage, podRestartCount, download, podsRestarting, podTerminatingCount, podsTerminating, fullPvcsCount, fullPvcs, namespaceTerminating, statusPageTemplateUri FROM Project WHERE pk=$1")
           .collecting(Collectors.toList())
           .execute(Tuple.of(pk)
           ).onSuccess(result -> {
@@ -5245,10 +5277,11 @@ public class ProjectEnUSGenApiServiceImpl extends BaseApiServiceImpl implements 
       o.persistForClass(Project.VAR_displayPage, Project.staticSetDisplayPage(siteRequest2, (String)result.get(Project.VAR_displayPage)));
       o.persistForClass(Project.VAR_gpuEnabled, Project.staticSetGpuEnabled(siteRequest2, (String)result.get(Project.VAR_gpuEnabled)));
       o.persistForClass(Project.VAR_editPage, Project.staticSetEditPage(siteRequest2, (String)result.get(Project.VAR_editPage)));
-      o.persistForClass(Project.VAR_podRestartCount, Project.staticSetPodRestartCount(siteRequest2, (String)result.get(Project.VAR_podRestartCount)));
+      o.persistForClass(Project.VAR_vllmEnabled, Project.staticSetVllmEnabled(siteRequest2, (String)result.get(Project.VAR_vllmEnabled)));
       o.persistForClass(Project.VAR_userPage, Project.staticSetUserPage(siteRequest2, (String)result.get(Project.VAR_userPage)));
-      o.persistForClass(Project.VAR_podsRestarting, Project.staticSetPodsRestarting(siteRequest2, (String)result.get(Project.VAR_podsRestarting)));
+      o.persistForClass(Project.VAR_podRestartCount, Project.staticSetPodRestartCount(siteRequest2, (String)result.get(Project.VAR_podRestartCount)));
       o.persistForClass(Project.VAR_download, Project.staticSetDownload(siteRequest2, (String)result.get(Project.VAR_download)));
+      o.persistForClass(Project.VAR_podsRestarting, Project.staticSetPodsRestarting(siteRequest2, (String)result.get(Project.VAR_podsRestarting)));
       o.persistForClass(Project.VAR_podTerminatingCount, Project.staticSetPodTerminatingCount(siteRequest2, (String)result.get(Project.VAR_podTerminatingCount)));
       o.persistForClass(Project.VAR_podsTerminating, Project.staticSetPodsTerminating(siteRequest2, (String)result.get(Project.VAR_podsTerminating)));
       o.persistForClass(Project.VAR_fullPvcsCount, Project.staticSetFullPvcsCount(siteRequest2, (String)result.get(Project.VAR_fullPvcsCount)));

--- a/src/main/java/org/computate/aitelemetry/model/tenant/TenantEnUSGenApiServiceImpl.java
+++ b/src/main/java/org/computate/aitelemetry/model/tenant/TenantEnUSGenApiServiceImpl.java
@@ -2532,19 +2532,24 @@ public class TenantEnUSGenApiServiceImpl extends BaseApiServiceImpl implements T
           Promise<Void> promise1 = Promise.promise();
           searchpageTenantPageInit(ctx, page, listTenant, promise1);
           promise1.future().onSuccess(b -> {
-            Promise<String> promise2 = Promise.promise();
-            templateSearchPageTenant(ctx, page, listTenant, promise2);
-            promise2.future().onSuccess(renderedTemplate -> {
-              try {
-                Buffer buffer = Buffer.buffer(renderedTemplate);
-                promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
-              } catch(Throwable ex) {
-                LOG.error(String.format("response200SearchPageTenant failed. "), ex);
+            try {
+              Promise<String> promise2 = Promise.promise();
+              templateSearchPageTenant(ctx, page, listTenant, promise2);
+              promise2.future().onSuccess(renderedTemplate -> {
+                try {
+                  Buffer buffer = Buffer.buffer(renderedTemplate);
+                  promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
+                } catch(Throwable ex) {
+                  LOG.error(String.format("response200SearchPageTenant failed. "), ex);
+                  promise.fail(ex);
+                }
+              }).onFailure(ex -> {
                 promise.fail(ex);
-              }
-            }).onFailure(ex -> {
-              promise.fail(ex);
-            });
+              });
+            } catch(Throwable ex) {
+              LOG.error(String.format("response200SearchPageTenant failed. "), ex);
+              promise.tryFail(ex);
+            }
           }).onFailure(ex -> {
             promise.tryFail(ex);
           });
@@ -2829,19 +2834,24 @@ public class TenantEnUSGenApiServiceImpl extends BaseApiServiceImpl implements T
           Promise<Void> promise1 = Promise.promise();
           editpageTenantPageInit(ctx, page, listTenant, promise1);
           promise1.future().onSuccess(b -> {
-            Promise<String> promise2 = Promise.promise();
-            templateEditPageTenant(ctx, page, listTenant, promise2);
-            promise2.future().onSuccess(renderedTemplate -> {
-              try {
-                Buffer buffer = Buffer.buffer(renderedTemplate);
-                promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
-              } catch(Throwable ex) {
-                LOG.error(String.format("response200EditPageTenant failed. "), ex);
+            try {
+              Promise<String> promise2 = Promise.promise();
+              templateEditPageTenant(ctx, page, listTenant, promise2);
+              promise2.future().onSuccess(renderedTemplate -> {
+                try {
+                  Buffer buffer = Buffer.buffer(renderedTemplate);
+                  promise.complete(new ServiceResponse(200, "OK", buffer, requestHeaders));
+                } catch(Throwable ex) {
+                  LOG.error(String.format("response200EditPageTenant failed. "), ex);
+                  promise.fail(ex);
+                }
+              }).onFailure(ex -> {
                 promise.fail(ex);
-              }
-            }).onFailure(ex -> {
-              promise.fail(ex);
-            });
+              });
+            } catch(Throwable ex) {
+              LOG.error(String.format("response200EditPageTenant failed. "), ex);
+              promise.tryFail(ex);
+            }
           }).onFailure(ex -> {
             promise.tryFail(ex);
           });

--- a/src/main/resources/sql/db-create.sql
+++ b/src/main/resources/sql/db-create.sql
@@ -168,6 +168,7 @@ ALTER TABLE Project ADD COLUMN IF NOT EXISTS description text;
 ALTER TABLE Project ADD COLUMN IF NOT EXISTS projectFieldOfScience text;
 ALTER TABLE Project ADD COLUMN IF NOT EXISTS projectActive boolean;
 ALTER TABLE Project ADD COLUMN IF NOT EXISTS gpuEnabled boolean;
+ALTER TABLE Project ADD COLUMN IF NOT EXISTS vllmEnabled boolean;
 ALTER TABLE Project ADD COLUMN IF NOT EXISTS podRestartCount integer;
 ALTER TABLE Project ADD COLUMN IF NOT EXISTS podsRestarting text[];
 ALTER TABLE Project ADD COLUMN IF NOT EXISTS podTerminatingCount integer;

--- a/src/main/resources/webroot/openapi3-enUS.yaml
+++ b/src/main/resources/webroot/openapi3-enUS.yaml
@@ -25511,6 +25511,8 @@ components:
                     type: boolean
                   gpuEnabled:
                     type: boolean
+                  vllmEnabled:
+                    type: boolean
                   podRestartCount:
                     type: string
                   podsRestarting:
@@ -25642,6 +25644,13 @@ components:
             removeGpuEnabled:
               type: boolean
             removeAllGpuEnabled:
+              type: boolean
+            setVllmEnabled:
+              type: boolean
+              nullable: true
+            removeVllmEnabled:
+              type: boolean
+            removeAllVllmEnabled:
               type: boolean
             setPodRestartCount:
               type: string
@@ -25862,6 +25871,13 @@ components:
               type: boolean
             removeAllGpuEnabled:
               type: boolean
+            setVllmEnabled:
+              type: boolean
+              nullable: true
+            removeVllmEnabled:
+              type: boolean
+            removeAllVllmEnabled:
+              type: boolean
             setPodRestartCount:
               type: string
               nullable: true
@@ -26011,6 +26027,8 @@ components:
               type: boolean
             gpuEnabled:
               type: boolean
+            vllmEnabled:
+              type: boolean
             podRestartCount:
               type: string
             podsRestarting:
@@ -26073,6 +26091,8 @@ components:
               type: boolean
             gpuEnabled:
               type: boolean
+            vllmEnabled:
+              type: boolean
             podRestartCount:
               type: string
             podsRestarting:
@@ -26134,6 +26154,8 @@ components:
             projectActive:
               type: boolean
             gpuEnabled:
+              type: boolean
+            vllmEnabled:
               type: boolean
             podRestartCount:
               type: string
@@ -26202,6 +26224,8 @@ components:
                     type: boolean
                   gpuEnabled:
                     type: boolean
+                  vllmEnabled:
+                    type: boolean
                   podRestartCount:
                     type: string
                   podsRestarting:
@@ -26263,6 +26287,8 @@ components:
                   projectActive:
                     type: boolean
                   gpuEnabled:
+                    type: boolean
+                  vllmEnabled:
                     type: boolean
                   podRestartCount:
                     type: string
@@ -26326,6 +26352,8 @@ components:
               type: boolean
             gpuEnabled:
               type: boolean
+            vllmEnabled:
+              type: boolean
             podRestartCount:
               type: string
             podsRestarting:
@@ -26387,6 +26415,8 @@ components:
             projectActive:
               type: boolean
             gpuEnabled:
+              type: boolean
+            vllmEnabled:
               type: boolean
             podRestartCount:
               type: string
@@ -27532,10 +27562,6 @@ components:
                     type: string
                   pageId:
                     type: string
-                  h1:
-                    type: string
-                  h2:
-                    type: string
                   pageImageUri:
                     type: string
                   pageImageWidth:
@@ -27713,20 +27739,6 @@ components:
             removePageId:
               type: string
             removeAllPageId:
-              type: string
-            setH1:
-              type: string
-              nullable: true
-            removeH1:
-              type: string
-            removeAllH1:
-              type: string
-            setH2:
-              type: string
-              nullable: true
-            removeH2:
-              type: string
-            removeAllH2:
               type: string
             setPageImageUri:
               type: string
@@ -28020,20 +28032,6 @@ components:
               type: string
             removeAllPageId:
               type: string
-            setH1:
-              type: string
-              nullable: true
-            removeH1:
-              type: string
-            removeAllH1:
-              type: string
-            setH2:
-              type: string
-              nullable: true
-            removeH2:
-              type: string
-            removeAllH2:
-              type: string
             setPageImageUri:
               type: string
               nullable: true
@@ -28236,10 +28234,6 @@ components:
               type: string
             pageId:
               type: string
-            h1:
-              type: string
-            h2:
-              type: string
             pageImageUri:
               type: string
             pageImageWidth:
@@ -28328,10 +28322,6 @@ components:
               type: string
             pageId:
               type: string
-            h1:
-              type: string
-            h2:
-              type: string
             pageImageUri:
               type: string
             pageImageWidth:
@@ -28419,10 +28409,6 @@ components:
             authorUrl:
               type: string
             pageId:
-              type: string
-            h1:
-              type: string
-            h2:
               type: string
             pageImageUri:
               type: string
@@ -28517,10 +28503,6 @@ components:
                     type: string
                   pageId:
                     type: string
-                  h1:
-                    type: string
-                  h2:
-                    type: string
                   pageImageUri:
                     type: string
                   pageImageWidth:
@@ -28608,10 +28590,6 @@ components:
                   authorUrl:
                     type: string
                   pageId:
-                    type: string
-                  h1:
-                    type: string
-                  h2:
                     type: string
                   pageImageUri:
                     type: string
@@ -28701,10 +28679,6 @@ components:
               type: string
             pageId:
               type: string
-            h1:
-              type: string
-            h2:
-              type: string
             pageImageUri:
               type: string
             pageImageWidth:
@@ -28792,10 +28766,6 @@ components:
             authorUrl:
               type: string
             pageId:
-              type: string
-            h1:
-              type: string
-            h2:
               type: string
             pageImageUri:
               type: string


### PR DESCRIPTION

<img width="1121" height="750" alt="image" src="https://github.com/user-attachments/assets/8379cb7b-4795-4e2b-b227-b47a6d2c6f74" />


- **accessTokenLifespan/ssoSessionIdleTimeout now 30 min**
When deploying AI Telemetry to OpenShift Local, the session idle timeout and
token lifespan should both be 30 minutes to prevent refresh tokens after 5
minutes.
- **Dynamic checking for GPU and VLLM enabled metric ranges**
Because AI projects have long periods without any GPU metrics or VLLM metrics,
we want to dynamically show these metrics when changing the range of the
dashboards.